### PR TITLE
Verify links logging

### DIFF
--- a/QWeb/internal/browser/chrome.py
+++ b/QWeb/internal/browser/chrome.py
@@ -89,7 +89,7 @@ def open_browser(executable_path="chromedriver", chrome_args=None,
                 CONFIG.set_value('Headless', True)
             for item in chrome_args:
                 options.add_argument(item.lstrip())
-        options.add_argument("start-maximized")
+        # options.add_argument("start-maximized")
         options.add_argument("--disable-notifications")
         if 'headless' in kwargs:
             CONFIG.set_value('Headless', True)

--- a/QWeb/internal/browser/chrome.py
+++ b/QWeb/internal/browser/chrome.py
@@ -89,7 +89,7 @@ def open_browser(executable_path="chromedriver", chrome_args=None,
                 CONFIG.set_value('Headless', True)
             for item in chrome_args:
                 options.add_argument(item.lstrip())
-        # options.add_argument("start-maximized")
+        options.add_argument("start-maximized")
         options.add_argument("--disable-notifications")
         if 'headless' in kwargs:
             CONFIG.set_value('Headless', True)

--- a/QWeb/keywords/browser.py
+++ b/QWeb/keywords/browser.py
@@ -309,8 +309,8 @@ def verify_links(url='current', log_all=False):
                 if status == 405:
                     r = requests.get(url, headers=headers)
                     status = r.status_code
-            except requests.exceptions.ConnectionError:
-                logger.error("{} can't be reached.".format(url))
+            except requests.exceptions.ConnectionError as e:
+                logger.error("{} can't be reached. Error message: {}".format(url, e))
                 broken.append(url)
                 continue
             if 399 < status < 600:


### PR DESCRIPTION
Currently if a requests.exceptions.ConnectionError happens, the error message isn't logged.