### PR TITLE
Ipr dbl click

### DIFF
--- a/QWeb/keywords/element.py
+++ b/QWeb/keywords/element.py
@@ -34,7 +34,12 @@ def click_element(xpath, timeout=0, js=False, index=1, **kwargs):
         ClickElement          //*[@id\="click_me"]
         ClickElement          xpath\=//*[@id\="click_me"]
 
-    To double-click element, use SetConfig
+    To double-click element, use argument doubleclick=True
+    .. code-block:: robotframework
+
+        ClickText             double_click_me       doubleclick=True
+
+    Or use SetConfig
 
     .. code-block:: robotframework
 
@@ -67,7 +72,7 @@ def click_element(xpath, timeout=0, js=False, index=1, **kwargs):
             kwargs.get('tag'), xpath, **kwargs)[index]
     else:
         web_element = element.get_unique_element_by_xpath(xpath)
-    if actions.execute_click_and_verify_condition(web_element, timeout=timeout, js=js):
+    if actions.execute_click_and_verify_condition(web_element, timeout=timeout, js=js, **kwargs):
         return
 
 

--- a/QWeb/keywords/text.py
+++ b/QWeb/keywords/text.py
@@ -318,7 +318,12 @@ def click_text(text, anchor="1", timeout=0, parent=None,
 
         ClickText   Canis     js=true     #Use Javascript click instead of Selenium
 
-    To double-click element, use SetConfig
+    To double-click text, use argument doubleclick=True
+    .. code-block:: robotframework
+
+        ClickText   Canis       doubleclick=True
+
+    Or use SetConfig
 
     .. code-block:: robotframework
 
@@ -348,7 +353,7 @@ def click_text(text, anchor="1", timeout=0, parent=None,
     anchor = str(anchor)
     web_element = internal_text.get_element_by_locator_text(
         text, anchor, parent=parent, child=child, **kwargs)
-    if execute_click_and_verify_condition(web_element, timeout=timeout, js=js):
+    if execute_click_and_verify_condition(web_element, timeout=timeout, js=js, **kwargs):
         return
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updates for ClickCell keyword: checks for index value and more descriptive documentation
+- Fixed DoubleClick argument usage consistency between keywords
 
 ## [1.0.4] - 2021-05-24
 ### Added

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -522,12 +522,34 @@ Child and Parents - JS click child
     VerifyText              smiley clicked!
 
 Doubleclick
-    [tags]	PROBLEM_IN_FIREFOX
+    [tags]	PROBLEM_IN_FIREFOX                       Doubleclick
     VerifyNoText            doubleclick test clicked!
     SetConfig               DoubleClick     On
     ClickText               double-click test.
     VerifyText              doubleclick test clicked!
     SetConfig               DoubleClick     Off
+
+Doubleclick with arguments
+    [tags]	Doubleclick
+    RefreshPage
+    VerifyNoText            doubleclick test clicked!    
+    ClickText               double-click test.      doubleclick=True
+    VerifyText              doubleclick test clicked!
+
+Doubleclick element with arguments
+    [tags]	Doubleclick
+    RefreshPage
+    VerifyNoText            doubleclick test clicked!    
+    ClickElement            //*[@id\="doubleclick test"]      doubleclick=True
+    VerifyText              doubleclick test clicked!
+
+Doubleclick item with arguments
+    [tags]	Doubleclick
+    RefreshPage
+    VerifyNoText            doubleclick test clicked!    
+    ClickItem               doubleclick test      doubleclick=True
+    VerifyText              doubleclick test clicked!
+
 
 VerifyAll String Without Source File With All Found
     [tags]	PROBLEM_IN_FIREFOX      verify_all


### PR DESCRIPTION
Fixed doupleclick=True argument usage. It was not working as expected with ClickText and ClickElement. Also added test cases.