### PR TITLE
Tko resetconfig mac fix

### DIFF
--- a/QWeb/internal/config.py
+++ b/QWeb/internal/config.py
@@ -61,10 +61,7 @@ class Config:
         if not self.is_value(_par):
             raise ValueError("Parameter {} doesn't exist".format(par))
         old_val, adapter_func = self.config[_par]
-        if adapter_func:
-            stored_value = adapter_func(value)
-        else:
-            stored_value = value
+        stored_value = adapter_func(value) if adapter_func else value
         self.config[_par] = (stored_value, adapter_func)
         return old_val
 
@@ -73,8 +70,17 @@ class Config:
         if par:
             _par = self._clean_string(par)
             self.config[_par] = copy.deepcopy(self._config_defaults[_par])
+            # trigger adapter func for clearkey
+            if "clearkey" in _par:
+                val, adapter_func = self.config[_par]
+                if adapter_func:
+                    adapter_func(str(val))
         else:
             self.config = copy.deepcopy(self._config_defaults)
+            # handle clearkey separately
+            _par = self._clean_string("ClearKey")
+            val, adapter_func = self.config[_par]
+            self.set_value(_par, str(val))
 
     def __getitem__(self, par):
         """ Allow accessing parameters in dictionary like syntax."""

--- a/QWeb/internal/input_handler.py
+++ b/QWeb/internal/input_handler.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-rf
 # --------------------------
 # Copyright © 2014 -            Qentinel Group.
 #

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updates for ClickCell keyword: checks for index value and more descriptive documentation
 - Fixed DoubleClick argument usage consistency between keywords
+- Fixed "ClearKey" not being reset when using ResetConfig
+- Fixed VerifyTextCount not failing when text is not found at all
 
 ## [1.0.4] - 2021-05-24
 ### Added


### PR DESCRIPTION
We'll have to handle "ClearKey" separately when doing ResetConfig. Without this change it does not reset back to original value, since original value is just copied over, but adapter func is not called.