### PR TITLE
Tko typesecret debugger rfw4

### DIFF
--- a/QWeb/internal/secrets.py
+++ b/QWeb/internal/secrets.py
@@ -58,7 +58,11 @@ def _filtered_start_keyword(keyword):
     LOGGER._started_keywords += 1
     LOGGER.log_message = LOGGER._log_message
     for logger in LOGGER.start_loggers:
-        logger.start_keyword(keyword)
+        try:
+            logger.start_keyword(keyword)
+        except AttributeError:
+            # AttributeError is raised on RFW 4.x under debugger
+            pass
     if apply_filter:
         b = BuiltIn()
         # Disable logging and store previous log level

--- a/test/acceptance/icon.robot
+++ b/test/acceptance/icon.robot
@@ -15,7 +15,7 @@ ${BASE_IMAGE_PATH}          ${CURDIR}${/}..${/}resources${/}pics_and_icons${/}ic
 Click icons
     [Tags]                  PROBLEM_IN_WINDOWS	PROBLEM_IN_FIREFOX  RESOLUTION_DEPENDENCY
     SetConfig               WindowSize          1920x1080
-    Sleep                   2
+    Sleep                   5
     ClickIcon               person
     VerifyText              person is my tooltip value!
     ClickIcon               lock

--- a/test/acceptance/requests.robot
+++ b/test/acceptance/requests.robot
@@ -20,7 +20,7 @@ Save file using icon as a locator
     VerifyItem      screen
     Run keyword and expect error    QWebFileNotFoundError:*
     ...             UsePdf      unnamediddqd11222333544485923.pdf
-    SaveFile        screen      anchor=2
+    SaveFile        screen      unnamed.pdf     anchor=2
     UsePdf          unnamed.pdf
     VerifyPdfText   Simple PDF File
     RemovePdf


### PR DESCRIPTION
Fixes issue of **TypeSecret** failing with AttributeError on RFW 4.x, when run under debugger

In addition minor modifications to 2 tests (not related to above)