### PR TITLE
QWeb channel added on Robot Framework Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Examples](#examples)
 - [Changelog](#changelog)
 - [Contribute](#contribute)
+- [Community](#community)
 - [License](#license)
 
 ---
@@ -173,6 +174,12 @@ Found an bug? Want to propose a new feature or improve documentation? Please sta
 
 [Back To The Top](#qweb)
 
+## Community
+
+Want to join the community at Slack? On the official Robot Framework workspace, there is a QWeb channel where you can discuss with others about keywords, issues and improvements. [Join Now](https://robotframework.slack.com/archives/C029L0N3N81)
+
+[Back To The Top](#qweb)
+
 ## License
 
 Apache 2.0 License. See [LICENSE](https://github.com/qentinelqi/qweb/blob/master/LICENSE).
@@ -195,5 +202,5 @@ Apache 2.0 License. See [LICENSE](https://github.com/qentinelqi/qweb/blob/master
 [pace-badge]: https://img.shields.io/badge/Tested%20with-Qentinel%20Pace-blue
 [python-versions-badge]: https://img.shields.io/pypi/pyversions/QWeb
 [pypi-badge]: https://img.shields.io/pypi/v/QWeb?color=green
-[slack-badge]: https://img.shields.io/badge/Slack-Robot%20Framework/QWeb-blue?style=flat-square&logo=Slack
+[slack-badge]: https://img.shields.io/badge/Slack-QWeb-blue?style=flat-square&logo=Slack
 [slack-url]: https://robotframework.slack.com/archives/C029L0N3N81

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![Linux Acceptance][linux_ci_badge]
 ![MacOS Acceptance][macos_ci_badge]
 [![Tested with][pace-badge]][pace-url]
+[![Slack][slack-badge]][slack-url]
 
 ### Table of Contents
 
@@ -194,3 +195,5 @@ Apache 2.0 License. See [LICENSE](https://github.com/qentinelqi/qweb/blob/master
 [pace-badge]: https://img.shields.io/badge/Tested%20with-Qentinel%20Pace-blue
 [python-versions-badge]: https://img.shields.io/pypi/pyversions/QWeb
 [pypi-badge]: https://img.shields.io/pypi/v/QWeb?color=green
+[slack-badge]: https://img.shields.io/badge/Slack-Robot%20Framework/QWeb-blue?style=flat-square&logo=Slack
+[slack-url]: https://robotframework.slack.com/archives/C029L0N3N81


### PR DESCRIPTION
I have created a QWeb channel on the official Robot Framework Slack.

QWeb Channel: [https://robotframework.slack.com/archives/C029L0N3N81](https://robotframework.slack.com/archives/C029L0N3N81)

The channel should be for more casual conversation and collaboration around QWeb, but any bugs/feature requests should still follow the [contributing guidelines](https://github.com/qentinelqi/qweb/blob/master/CONTRIBUTING.md).

The commits included will add a Slack badge and a Community section to the README.