### PR TITLE
62 some keywords do not accept first argument as a named argument

### DIFF
--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -179,21 +179,22 @@ def _equal_sign_handler(args, kwargs, function_name):
         locator = args[0]
     except IndexError:
         for key, value in kwargs.items():
-            # if present these are always the first argument
+            # if present any of these is always the first argument
+            # locator can be the 2nd arg but it is handled later on
             if key in ('locator', 'xpath', 'steps',
-                        'image', 'input_texts', 'input_values',
-                        'text', 'coordinates', 'texts_to_verify',
-                        'url', 'title'):
+                       'image', 'input_texts', 'input_values',
+                       'text', 'coordinates', 'texts_to_verify',
+                       'url', 'title'):
                 locator = value
                 break
         else:
             # index can be unnamed first argument or named argument
             locator = kwargs.get('index', None)
-        
-        # The only decorated method with locator as NOT the first argument
+
+        # The only decorated method with 'locator' as NOT the first argument
         if str(function_name) == "scroll_to":
             locator = kwargs.get('text_to_find', None)
-        
+
     if locator is None:
-        raise QWebElementNotFoundError("If xpath is an unnamed argument you need to escape '=' characters in xpath: '//div[@class\\=\"name\"]'\nOr you can give xpath as a named argument: 'xpath=//div[@class=\"name\"]'")
+        raise QWebElementNotFoundError("Use \\= instead of = in xpaths")
     return args, kwargs, locator

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -177,6 +177,23 @@ def _equal_sign_handler(args, kwargs, function_name):
             kwargs.clear()
     try:
         locator = args[0]
-    except IndexError as ie:
-        raise QWebElementNotFoundError("Use \\= instead of = in xpaths") from ie
+    except IndexError:
+        for key, value in kwargs.items():
+            # if present these are always the first argument
+            if key in ('locator', 'xpath', 'steps',
+                        'image', 'input_texts', 'input_values',
+                        'text', 'coordinates', 'texts_to_verify',
+                        'url', 'title'):
+                locator = value
+                break
+        else:
+            # index can be unnamed first argument or named argument
+            locator = kwargs.get('index', None)
+        
+        # The only decorated method with locator as NOT the first argument
+        if str(function_name) == "scroll_to":
+            locator = kwargs.get('text_to_find', None)
+        
+    if locator is None:
+        raise QWebElementNotFoundError("If xpath is an unnamed argument you need to escape '=' characters in xpath: '//div[@class\\=\"name\"]'\nOr you can give xpath as a named argument: 'xpath=//div[@class=\"name\"]'")
     return args, kwargs, locator

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -37,15 +37,39 @@ Click Element by xpath 2
     ClickElement                xpath\=//*[@value\="Button4"]
     VerifyText                  Button4 was clicked
 
+Click Element by xpath 3
+    Go To                       file://${CURDIR}/../resources/text.html
+    Verify No Text              Button4 was clicked
+    ClickElement                xpath=//*[@value\="Button4"]
+    VerifyText                  Button4 was clicked
+
+Click Element by xpath 4
+    Go To                       file://${CURDIR}/../resources/text.html
+    Verify No Text              Button4 was clicked
+    ClickElement                xpath=//*[@value="Button4"]
+    VerifyText                  Button4 was clicked
+
 Click Element by WebElement instance
     [Tags]                      WebElement
     Go To                       file://${CURDIR}/../resources/text.html
     ${elem}=                    GetWebElement               Button4                        element_type=text
-    ClickElement                xpath\=//*[@value\="Button4"]
+    ClickElement                ${elem}
     VerifyText                  Button4 was clicked
 
 IsElementFound
     ${found}=                   IsElement                   //*[@id\="hover_me"]
+    Should Be Equal             ${found}                    ${TRUE}
+
+IsElementFound 2
+    ${found}=                   IsElement                   xpath\=//*[@id\="hover_me"]
+    Should Be Equal             ${found}                    ${TRUE}
+
+IsElementFound 3
+    ${found}=                   IsElement                   xpath=//*[@id\="hover_me"]
+    Should Be Equal             ${found}                    ${TRUE}
+
+IsElementFound 3
+    ${found}=                   IsElement                   xpath=//*[@id="hover_me"]
     Should Be Equal             ${found}                    ${TRUE}
 
 IsElementFoundDelay

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -68,7 +68,7 @@ IsElementFound 3
     ${found}=                   IsElement                   xpath=//*[@id\="hover_me"]
     Should Be Equal             ${found}                    ${TRUE}
 
-IsElementFound 3
+IsElementFound 4
     ${found}=                   IsElement                   xpath=//*[@id="hover_me"]
     Should Be Equal             ${found}                    ${TRUE}
 

--- a/test/acceptance/swipe.robot
+++ b/test/acceptance/swipe.robot
@@ -40,7 +40,8 @@ Swipe with starting points and verify images
     VerifyIcon      person
 
 ScrollTo
-    [Tags]            ScrollTo
+    [Tags]            ScrollTo  RESOLUTION_DEPENDENCY
+    SetConfig         WindowSize   1600x900
     GoTo              file://${CURDIR}/../resources/text.html
     ScrollTo          Current scroll
     # Verify that we have scrolled (default text "scroll the window" has vanished)


### PR DESCRIPTION
Fix and acceptance tests.

Should not break anything as the fix addresses resolution of returnable `locator` variable in `_equal_sign_handler()`.
This variable is used only for logging purposes in the `timeout_decorator()` which is the only method which calls `_equal_sign_handler()`