### PR TITLE
Restore original DefaultTimeout after debugging is finished

### DIFF
--- a/QWeb/keywords/debug.py
+++ b/QWeb/keywords/debug.py
@@ -56,7 +56,7 @@ def debug_on(mode='draw'):
     CONFIG.set_value('DefaultTimeout', 2)
     CONFIG.set_value('Debug_Run', True)
     dbg.debug()
-
+    CONFIG.set_value('DefaultTimeout', cur_timeout)
 
 @keyword(tags=("Debug", "Error handling"))
 def debug_off():


### PR DESCRIPTION
Fixes bug #66 