### PR TITLE
Safari fixes

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -63,7 +63,7 @@ jobs:
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
         matchbox-window-manager -use_titlebar no &
         python -c "import pyautogui; print(pyautogui.size())"
-        python -m robot --exitonfailure -e jailed -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_LINUX -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
     - name: Acceptance tests Firefox
       if: matrix.browser == 'firefox'
       run: |
@@ -71,7 +71,7 @@ jobs:
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
         matchbox-window-manager -use_titlebar no &
         python -c "import pyautogui; print(pyautogui.size())"
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_FIREFOX -v BROWSER:Firefox -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_LINUX -e PROBLEM_IN_FIREFOX -v BROWSER:Firefox -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}
       uses: actions/upload-artifact@v1

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-        browser: [chrome, firefox, edge]
+        browser: [chrome, safari, edge]
 
     steps:
     - uses: actions/checkout@v2
@@ -61,10 +61,10 @@ jobs:
       if: matrix.browser == 'chrome'
       run: |
         python -m robot --exitonfailure -e jailed -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Firefox
-      if: matrix.browser == 'firefox'
+    - name: Acceptance tests Safari
+      if: matrix.browser == 'safari'
       run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_FIREFOX -e PROBLEM_IN_SAFARI -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:firefox -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_SAFARI -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:safari -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
     - name: Acceptance tests Edge
       if: matrix.browser == 'edge'
       run: |

--- a/QWeb/internal/actions.py
+++ b/QWeb/internal/actions.py
@@ -110,9 +110,7 @@ def execute_click_and_verify_condition(web_element, text_appear=True, **kwargs):
         timeout = How long we are trying if element is not enabled or some other error exists
         js = if js parameter exists, try javascript click instead of selenium
     """
-    driver = browser.get_current_browser()
-    is_safari = driver.capabilities['browserName'].lower() in browser.safari.NAMES
-    js = True if is_safari else util.par2bool(kwargs.get('js', False))
+    js = True if util.is_safari() else util.par2bool(kwargs.get('js', False))
     dbl_click = util.par2bool(kwargs.get('doubleclick', CONFIG["DoubleClick"]))
     if web_element.is_enabled():
         try:
@@ -303,8 +301,7 @@ def get_select_options(select, expected=None, **kwargs):  # pylint: disable=unus
 @decorators.timeout_decorator_for_actions
 def hover_to(web_element, timeout=0):  # pylint: disable=unused-argument
     driver = browser.get_current_browser()
-    # firefox specific fix
-    #if driver.capabilities['browserName'].lower() in browser.firefox.NAMES:
+    # firefox & safari specific fix
     needs_js_scroll = [x for x in [browser.firefox.NAMES, browser.safari.NAMES]
                        if driver.capabilities['browserName'].lower() in x]
     if needs_js_scroll:

--- a/QWeb/internal/browser/safari.py
+++ b/QWeb/internal/browser/safari.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from QWeb.internal import browser
 
 NAMES = ["safari", "sf"]
+open_windows = []
 
 
 def open_browser(port=0, executable_path='/usr/bin/safaridriver',
@@ -15,4 +16,5 @@ def open_browser(port=0, executable_path='/usr/bin/safaridriver',
                               desired_capabilities, quiet)
     driver.maximize_window()
     browser.cache_browser(driver)
+    open_windows.append(driver.current_window_handle)
     return driver

--- a/QWeb/internal/input_handler.py
+++ b/QWeb/internal/input_handler.py
@@ -122,7 +122,7 @@ class InputHandler:
             return None
         if key == '{PASTE}':
             return pyperclip.paste()
-        hotkey = ""
+        hotkey = []
         if key.startswith('{') and key.endswith('}'):
             key = key[1:-1].upper()
             if '+' in key:
@@ -132,7 +132,7 @@ class InputHandler:
                         key = getattr(Keys, k.strip())
                     except AttributeError:
                         key = k.lower().strip()
-                    hotkey += key
+                    hotkey.append(key)
                 return hotkey
             key = getattr(Keys, key)
         return key

--- a/QWeb/internal/util.py
+++ b/QWeb/internal/util.py
@@ -198,6 +198,11 @@ def is_retina():
     return False
 
 
+def is_safari():
+    driver = browser.get_current_browser()
+    return driver.capabilities['browserName'].lower() in browser.safari.NAMES
+
+
 def get_browser_width():
     driver = browser.get_current_browser()
     size = driver.get_window_size()

--- a/QWeb/internal/window.py
+++ b/QWeb/internal/window.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 # ---------------------------
 
-from QWeb.internal import browser, text
+from QWeb.internal import browser, text, util
 from QWeb.internal.exceptions import QWebDriverError
+from QWeb.internal.browser.safari import open_windows
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 from robot.api import logger
@@ -28,7 +29,7 @@ def get_window_handles():
     if driver is None:
         raise QWebDriverError("No browser open. Use OpenBrowser keyword"
                               " to open browser first")
-    return driver.window_handles
+    return open_windows if util.is_safari() else driver.window_handles
 
 
 def get_current_window_handle():
@@ -37,6 +38,17 @@ def get_current_window_handle():
         raise QWebDriverError("No browser open. Use OpenBrowser keyword"
                               " to open browser first")
     return driver.current_window_handle
+
+
+def append_new_windows_safari():
+    """ Safari returns window handles in random order.
+        We must keep track of opened windows in safari.
+        This function will append new open windows to global list."""
+    driver = browser.get_current_browser()
+    all_handles = driver.window_handles
+    for i in all_handles:
+        if i not in open_windows:
+            open_windows.append(i)
 
 
 def get_url():

--- a/QWeb/keywords/browser.py
+++ b/QWeb/keywords/browser.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ---------------------------
-
 import os
 import pkg_resources
 import requests
@@ -245,6 +244,8 @@ def close_browser():
     """
     driver = browser.get_current_browser()
     if driver is not None:
+        if util.is_safari():
+            safari.open_windows.clear()
         _close_remote_browser_session(driver, close_only=True)
         browser.remove_from_browser_cache(driver)
 
@@ -310,6 +311,9 @@ def close_all_browsers():
 
     # Clear browser re-use flag as no session open anymore
     BuiltIn().set_global_variable('${BROWSER_REUSE}', False)
+
+    # safari specific
+    safari.open_windows = []
 
     # Set 'Headless' flag as False, since no session open anymore
     CONFIG.set_value('Headless', False)

--- a/QWeb/keywords/browser.py
+++ b/QWeb/keywords/browser.py
@@ -313,7 +313,7 @@ def close_all_browsers():
     BuiltIn().set_global_variable('${BROWSER_REUSE}', False)
 
     # safari specific
-    safari.open_windows = []
+    safari.open_windows.clear()
 
     # Set 'Headless' flag as False, since no session open anymore
     CONFIG.set_value('Headless', False)

--- a/QWeb/keywords/input_.py
+++ b/QWeb/keywords/input_.py
@@ -692,8 +692,7 @@ def press_key(locator, key, anchor="1", timeout='0', **kwargs):
             locator, anchor, timeout=timeout, index=1, **kwargs)
         key = input_handler.check_key(key)
 
-        is_safari = driver.capabilities['browserName'].lower() in browser.safari.NAMES
-        if key[0] == '\ue03d' and is_safari:  # COMMAND key workaround on safari
+        if key[0] == '\ue03d' and util.is_safari():  # COMMAND key workaround on safari
             javascript.execute_javascript("arguments[0].focus();", input_element)
             action.key_down(key[0]) \
                   .send_keys(key[1]) \

--- a/QWeb/keywords/input_.py
+++ b/QWeb/keywords/input_.py
@@ -692,7 +692,10 @@ def press_key(locator, key, anchor="1", timeout='0', **kwargs):
             locator, anchor, timeout=timeout, index=1, **kwargs)
         key = input_handler.check_key(key)
 
-        if key[0] == '\ue03d' and util.is_safari():  # COMMAND key workaround on safari
+        # COMMAND key workaround on safari
+        # supports normal text field CMD operations only
+        # (i.e. CMD+C, CMD+A, CMD+V etc.)
+        if len(key) == 2 and key[0] == '\ue03d' and util.is_safari():
             javascript.execute_javascript("arguments[0].focus();", input_element)
             action.key_down(key[0]) \
                   .send_keys(key[1]) \

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -49,6 +49,7 @@ Test Dropdown Keyword With Value
     [Documentation]             Tests choosing dropdown with value instead of text, with CSSSelectors on
     ...                         and off.
     VerifyNotext                bear
+    HoverText                   Joulupukki
     Dropdown                    Joulupukki                  bear
     VerifyText                  bear
     VerifyNoText                boar

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -166,6 +166,7 @@ Locate dropdowns with anchor 2
 Select and unselect in multiselection dropdown
     [Documentation]             Test for multiple selection dropdowns
     RefreshPage
+    HoverText                   Choose a spacecraft
     DropDown                    Choose a spacecraft         USS Defiant
     DropDown                    Choose a spacecraft         Scimitar
     DropDown                    Choose a spacecraft         Galileo

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -71,7 +71,7 @@ ElementNotFound
     ...                         ClickElement                //*[id\='qwerty']           timeout=2
 
 DoubleClick Element
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]
     VerifyNoText                doubleclick test clicked!
     SetConfig                   DoubleClick                 On
     ClickElement                //*[@id\="doubleclick test"]
@@ -79,7 +79,9 @@ DoubleClick Element
     SetConfig                   DoubleClick                 Off
 
 Use attributes without xpath to get element
+    [Tags]
     RefreshPage
+    HoverText                   Lorem ipsum
     HoverElement                hover_me                    tag=button
     VerifyText                  Hover Link
     ClickElement                screen                      tag=img

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -10,14 +10,16 @@ ${BROWSER}                      chrome
 
 *** Test Cases ***
 Refresh Page
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame    Refresh
     ClickText                   Button1
     VerifyText                  Button1 was clicked
     RefreshPage
-    VerifyNoText                Button1 was clicked
+    VerifyNoText                Button1 was clicked    timeout=5
+    SetConfig                   StayInCurrentFrame    False
+    VerifyText                  Text in frame
 
 Back & Forward
-    [Tags]
+    [Tags]                      Frame    Back    Forward
     GoTo                        about:blank
     VerifyUrl                   about:blank
     VerifyNoText                Button1
@@ -32,14 +34,14 @@ Back & Forward
     Back
 
 Use Frame And Use Page
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame
     VerifyText                  Text not in frame
     VerifyText                  Text in frame
     VerifyText                  Text not in frame
     VerifyText                  Text in frame
 
 Automatic frame search text elements
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame                   
     SetConfig                   DefaultDocument             True
     VerifyNoText                Button3 was clicked
     ScrollText                  Button3
@@ -48,7 +50,7 @@ Automatic frame search text elements
     ScrollText                  Input fields with
 
 Automatic frame search input elements
-    [tags]                      inputs                      PROBLEM_IN_SAFARI
+    [tags]                      inputs                      
     TypeText                    First input                 Robot
     TypeText                    Second input                QENROB
     TypeText                    Cell 1 input                20022019
@@ -63,7 +65,7 @@ Automatic frame search input elements
     ShouldbeEqual               ${value}                    I'am catching you too..
 
 Automatic frame search table elements
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame
     UseTable                    Sample
     TypeText                    r4c1                        Qentiro
     TypeText                    r4c2                        Robot
@@ -78,7 +80,7 @@ Automatic frame search table elements
 
 
 Automatic frame search checkbox elements
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame
     SetConfig                   CSSSelectors                off
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled
@@ -94,7 +96,7 @@ Automatic frame search checkbox elements
     VerifyCheckboxValue         I have a car                off
 
 Automatic frame search dropdown elements
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame
     SetConfig                   CSSSelectors                on
     Dropdown                    label without               Rules
     VerifySelectedOption        label without               Rules
@@ -102,7 +104,7 @@ Automatic frame search dropdown elements
     VerifyOption                label without               Qentinel
 
 Automatic frame search back and forth between frames
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame                
     Dropdown                    label without               Rules
     VerifySelectedOption        label without               Rules
     TypeText                    First input                 Robot
@@ -117,19 +119,19 @@ Automatic frame search back and forth between frames
     ScrollText                  Input fields with
 
 IsText in different frame
-    [Tags]                      istext                      PROBLEM_IN_SAFARI
+    [Tags]                      istext
     ClickCheckbox               I have a bike               on
     ${found}=                   IsText                      Last name:
     Should Be Equal             ${found}                    ${TRUE}
 
 IsNoText in different frame
-    [Tags]                      istext                      PROBLEM_IN_SAFARI
+    [Tags]                      istext
     ClickCheckbox               I have a bike               on
     ${notfound}=                IsNoText                    Last name:                  0.1s
     Should Be Equal             ${notfound}                 ${FALSE}
 
 Upload files with index
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame    Upload
     UploadFile                  1                           test1.txt
     ExecuteJavaScript           return document.querySelector('#myFile1').value         $value
     ShouldBeEqual               ${value}                    C:\fakepath\test1.txt
@@ -138,12 +140,13 @@ Upload files with index
     ShouldBeEqual               ${value}                    C:\fakepath\test2.txt
 
 Upload files with locator
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Frame    Upload
     UploadFile                  Uploadme                    test1.txt
     ExecuteJavaScript           return document.querySelector('#myFile1').value         $value
     ShouldBeEqual               ${value}                    C:\fakepath\test1.txt
 
 Upload with xpath
+    [Tags]                      Frame    Upload
     UploadFile                  //*[@id\='myFile3']         test2.txt
     ExecuteJavaScript           return document.querySelector('#myFile3').value         $value
     ShouldBeEqual               ${value}                    C:\fakepath\test2.txt

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -70,11 +70,13 @@ Type Text
     VerifyInputValue        xpath\=//input[@id\="r2c2"]   22
 
 Type Text Another Input Field To The Left
+    [Tags]                  jailed
     Log                     Not implemented correctly yet
     #TypeText               row1column3             13
     #VerifyInputValue       xpath\=//input[@id\="r1c3"]   13
 
 Type Text into Tel Type Inputbox
+    [Tags]                  PROBLEM_IN_SAFARI
     SetConfig               CSSSelectors            False
     TypeText                row2column4             33
     VerifyInputValue        xpath\=//input[@id\="r2c3"]   33
@@ -86,6 +88,7 @@ TypeText but box id delayed
     VerifyInputValue        //*[@id\='hide']         not hidden
 
 Verify Input Value Empty
+    [Tags]                  jailed
     Log                     Not implemented correctly yet
     #VerifyInputValue       row1column1             ${EMPTY}
 
@@ -140,7 +143,7 @@ VerifyInputStatus enabled when ReadOnly exists
     ...     VerifyInputStatus   ronly   readonly  timeout=0.2s
 
 Verify Input Handler
-    [Tags]                  PROBLEM_IN_WINDOWS
+    [Tags]                  PROBLEM_IN_WINDOWS    PROBLEM_IN_SAFARI
     SetConfig               InputHandler            raw
     TypeText                username                Qentinel
     SetConfig               InputHandler            selenium
@@ -172,14 +175,14 @@ Verify search strategy placeholders
     ...   SetConfig               MatchingInputElement       //*[@type\="{} {0}"]
 
 Set Line Break Tab
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_FIREFOX
     SetConfig               LineBreak               \t
     VerifyNoText            on focus
     TypeText                end-key                 dummytext
     VerifyNoText            on focus
 
 Set Line Break Empty
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI     empty_line_break	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      empty_line_break	PROBLEM_IN_FIREFOX
     SetConfig               LineBreak               \ue000
     VerifyNoText            on focus
     TypeText                end-key                 dummytext
@@ -187,7 +190,7 @@ Set Line Break Empty
     RefreshPage
 
 Set Line Break Empty 2
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI     empty_line_break	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      empty_line_break	PROBLEM_IN_FIREFOX
     SetConfig               LineBreak               Empty
     VerifyNoText            on focus
     TypeText                end-key                 dummytext
@@ -195,7 +198,7 @@ Set Line Break Empty 2
     RefreshPage
 
 Set Line Break Empty 3
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI     empty_line_break	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      empty_line_break	PROBLEM_IN_FIREFOX
     SetConfig               LineBreak               None
     VerifyNoText            on focus
     TypeText                end-key                 dummytext
@@ -203,7 +206,7 @@ Set Line Break Empty 3
     RefreshPage
 
 Set Line Break Empty 4
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI     empty_line_break	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      empty_line_break	PROBLEM_IN_FIREFOX
     SetConfig               LineBreak               Null
     VerifyNoText            on focus
     TypeText                end-key                 dummytext
@@ -211,7 +214,7 @@ Set Line Break Empty 4
     RefreshPage
 
 Set Line Break None
-    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_SAFARI	PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_WINDOWS      PROBLEM_IN_FIREFOX
     # first we need to clear the focus from previous test case
     SetConfig               LineBreak               \t
     TypeText                end-key                 dummytext
@@ -388,7 +391,7 @@ TypeTexts and VerifyInputValues
     VerifyInputValues    test4.txt
 
 TypeTexts and VerifyInputValues fail
-    [tags]	PROBLEM_IN_FIREFOX
+    [tags]	PROBLEM_IN_FIREFOX    PROBLEM_IN_SAFARI
     ${message}=  Set Variable  QWebValueError: Unknown input value. Text file or*
     Run Keyword And Expect Error        ${message}
     ...    VerifyInputValues    bad_parameter.xlsx

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -326,6 +326,19 @@ PressKey test hotkeys
     PressKey                username              {CONTROL + V}
     VerifyInputValue        username              Kalakalle
 
+PressKey test hotkeys - Mac
+    [documentation]         Use keyboard shortcuts with press key
+    [tags]                  PROBLEM_IN_WINDOWS    PROBLEM_IN_LINUX
+    RefreshPage
+    TypeText                The Brave             Kalakalle
+    VerifyInputValue        The Brave             Kalakalle
+    PressKey                The Brave             {COMMAND + A}
+    PressKey                The Brave             {COMMAND + C}
+    PressKey                The Brave             {BACKSPACE}
+    VerifyInputValue        The Brave             ${EMPTY}
+    PressKey                username              {COMMAND + V}
+    VerifyInputValue        username              Kalakalle
+
 GetInputValue get substring
     TypeText                username                Write some random words and number 25.11.2019
     ${substring}            GetInputValue           username    between=some???words

--- a/test/acceptance/no_body.robot
+++ b/test/acceptance/no_body.robot
@@ -10,7 +10,7 @@ ${BROWSER}    chrome
 
 *** Test Cases ***
 Verify Text Under One Tag
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
     VerifyText              Click the button to open a new browser window.
     ClickText               Avaa ikkuna
     Switch Window           NEW

--- a/test/acceptance/selectors.robot
+++ b/test/acceptance/selectors.robot
@@ -16,6 +16,7 @@ Use selector attribute instead of xpath syntax
     HoverElement            screen          selector=data-icon
     ClickElement            screen          selector=data-icon
     VerifyText              Clicks: 1
+    HoverText               Flow
     DropDown                dropdown9       optionx        selector=id
     VerifySelectedOption    dropdown9       optionx        selector=id
 

--- a/test/acceptance/shadow_dom.robot
+++ b/test/acceptance/shadow_dom.robot
@@ -28,7 +28,7 @@ Basic inteactions with Shadow DOM
     ClickText              Click me
     VerifyAlertText        Alert from button
     CloseAlert             Accept
-    ClickText              Link
+    ClickText              Link                        delay=2
     VerifyText             Alert popup
 
 

--- a/test/acceptance/shadow_dom.robot
+++ b/test/acceptance/shadow_dom.robot
@@ -26,9 +26,11 @@ Basic inteactions with Shadow DOM
     TypeText               Input2                        Test456
     
     ClickText              Click me
-    VerifyAlertText        Alert from button
-    CloseAlert             Accept
-    ClickText              Link                        delay=2
+    VerifyText             hidden
+    ClickText              Click me
+    VerifyNoText           hidden
+
+    ClickText              Link
     VerifyText             Alert popup
 
 
@@ -45,8 +47,7 @@ Shadow DOM with attributes
     Log Screenshot
     ResetConfig            HighlightColor
     ClickItem              myButton
-    VerifyAlertText        Alert from button
-    CloseAlert             Accept
+    VerifyText             hidden
 
 
 VerifyAll & VerifyAny with shadow DOM

--- a/test/acceptance/table.robot
+++ b/test/acceptance/table.robot
@@ -40,7 +40,7 @@ Type text to table and verify values
     ...   VerifyInputValue              r4c4        2019-02-23          timeout=1
 
 Get Cell Value to variable
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
     UseTable                Sample
     ${TEST}                 GetCellText             r2c3
     ShouldBeEqual           ${TEST}                 ${EMPTY}

--- a/test/acceptance/table2.robot
+++ b/test/acceptance/table2.robot
@@ -17,6 +17,7 @@ Use table kw:s with text locator
     UseTable                Stars
     VerifyTable             r?Jimi/c?Age           27
     VerifyTable             r?Buddy/c?Date         1959-02-03
+    HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Qentiro
     DropDown                r?Qentiro/c?Some       Ruotsi
     VerifySelectedOption    r2c5                   Ruotsi
@@ -32,6 +33,7 @@ Use table kw:s with xpath locators
     UseTable                Stars
     VerifyTable             r?Jimi/c?Age           27
     VerifyTable             r?Buddy/c?Date         1959-02-03
+    HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Qentiro
     DropDown                r?Qentiro/c?Some       Ruotsi
     VerifySelectedOption    r2c5                   Ruotsi
@@ -72,8 +74,9 @@ Verify Multiple
     VerifyTable             r2c4                    1970*
 
 Use general kw:s with Table using cell coordinates as an locator
-    [Tags]                  PROBLEM_IN_SAFARI       kk
+    [Tags]
     SetConfig               CSSSelectors            on
+    HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Qentiro
     TypeText                r1c2                    Test Automation
     VerifyInputValue        r1c2                    Test Automation
@@ -95,8 +98,9 @@ Use general kw:s with Table using cell coordinates as an locator
     DropDown                r2c5                    Norja
 
 Use general kws with Table Get row by text or start counting from last cell
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
     SetConfig               PartialMatch            False
+    HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Robot
     ClickCheckBox           r?Qentiro/c1            On
     VerifyCheckBoxValue     r2c1                    On
@@ -112,12 +116,14 @@ Use general kws with Table Get row by text or start counting from last cell
     DropDown                r?Random/c1             Norja
     VerifySelectedOption    r-2c1                   Norja
     ClickCell               r?Text Node/c6
+    ExecuteJavascript       window.scrollTo(0, document.body.scrollHeight);    # scroll to bottom, safari needs this
     DropDown                r-1c2                   Robot
     VerifySelectedOption    r6c2                    Robot
     ClickCell               r-1c6
 
 Anchors and indexes
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
+    HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Text Node
     #Using index anchor(2)
     ClickCell               r?Text/c6               2
@@ -158,6 +164,7 @@ Anchors and indexes
     DropDown                r-2c2                   Qentinel
     DropDown                r-1c2                   Robot
     ClickCell               r?Text/c6               Node
+    ExecuteJavascript       window.scrollTo(0, document.body.scrollHeight);    # scroll to bottom, safari needs this
     DropDown                r-1c2                   Robot
     ClickCheckbox           r-1c2                   On
     TypeText                r-1c3                   new ind\=1
@@ -170,7 +177,7 @@ Anchors and indexes
     VerifyCheckBoxValue     r-1c6                   On                      index=2
 
 Using Cells, starts from last one
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
     UseTable                Some Text
     ClickCheckbox           r-1c-1                  On
     ClickCheckbox           r-1c-1                  Off                     index=2
@@ -188,7 +195,7 @@ Using Cells, starts from last one
     TypeText                r-1c-4                  -4 ind\=1
 
 Get row index and cell values to variables
-    [Tags]                  PROBLEM_IN_SAFARI
+    [Tags]
     SetConfig               CSSSelectors            True
     UseTable                Some Text
     ${row1}                 GetTableRow             //last

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -99,7 +99,7 @@ VerifyTextCountFail
     ...                     VerifyTextCount         Counttextyjku    4   timeout=1s
 
 VerifyTextCountDelay
-    [Tags]                  VerifyTextCount     PROBLEM_IN_SAFARI
+    [Tags]                  VerifyTextCount
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyTextCount         Counttextyjku    3
     ClickText               Counttextyjku    anchorcount
@@ -187,7 +187,7 @@ GetText Use between parameter to get substring
     ShouldBeEqual           ${text}                 This sentence contains
 
 GetText Use from start parameter to get substring
-    [Tags]                  sub
+    [Tags]                  sub                     PROBLEM_IN_SAFARI
     ${text}                 GetText                 dolor   from_start=5
     ShouldBeEqual           ${text}                 Lorem
     ${text}                 GetText                 dolor   between=deserunt???     from_start=7
@@ -478,9 +478,10 @@ ClickItemUntil
     Run Keyword and Expect Error   ${message}  ClickItemUntil   Clicks: 4    screen  timeout=2
 
 Hover Text small window
-    [Tags]                  PROBLEM_IN_SAFARI   PROBLEM_IN_FIREFOX
+    [Tags]                  PROBLEM_IN_FIREFOX
     # Bug https://qentinel.visualstudio.com/Pace_libraries/_workitems/edit/3364
     SetConfig               WindowSize              576X356
+    HoverText               Button1
     VerifyNoText            Hover Link
     HoverText               Hover Dropdown
     VerifyText              Hover Link
@@ -617,7 +618,7 @@ VerifyAny From List With None Found
     Run Keyword and Expect Error   *   VerifyAny      ${iddqd}   
 
 WriteText error in headless mode
-    [tags]	PROBLEM_IN_FIREFOX
+    [tags]	PROBLEM_IN_FIREFOX    PROBLEM_IN_SAFARI
     [Documentation]     Headless mode is used in suite setup, if that gets changed this test needs
     ...                 to be fixed as well.
     ${error}      Set Variable    QWebEnvironmentError: Running in headless*

--- a/test/acceptance/window.robot
+++ b/test/acceptance/window.robot
@@ -11,20 +11,21 @@ ${BROWSER}                      chrome
 
 *** Test Cases ***
 Go To
+    [Tags]                      Window    GoTo
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Should Be Equal             ${driver.current_url}       about:blank
     GoTo                        file://${CURDIR}/../resources/window.html
     Should Be Equal             ${driver.title}             Window Acceptance Tests
 
 Open Window
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    OpenWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     OpenWindow
     Length Should Be            ${driver.window_handles}    2
 
 Open Window Changed To New Window
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    OpenWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -32,7 +33,7 @@ Open Window Changed To New Window
     Should Be Equal             ${driver.current_url}       about:blank
 
 Close Window
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    OpenWindow    CloseWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     OpenWindow
@@ -41,7 +42,7 @@ Close Window
     Length Should Be            ${driver.window_handles}    1
 
 Switch Window
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -52,7 +53,7 @@ Switch Window
     Should Be Equal             ${driver.title}             Window Acceptance Tests
 
 Switch window, check context
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -64,7 +65,7 @@ Switch window, check context
     VerifyText                  Liirum laarum
 
 Switch window, special parameter NEW
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -84,6 +85,7 @@ Switch window, special parameter NEW
     VerifyText                  Liirum laarum
 
 Switch window, alphanumeric parameters
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -95,7 +97,7 @@ Switch window, alphanumeric parameters
 
 
 Switch window, multiple closings, check context
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -116,13 +118,14 @@ Switch window, multiple closings, check context
     VerifyText                  Liirum laarum
 
 Switch window, no other window
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     Run Keyword And Expect Error                            QWebDriverError: Tried to select tab with index 2 but there are only 1 tabs open
     ...                         Switch Window               2
 
 Switch Window, delay
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     Execute Javascript          setTimeout('window.open()', 3000);
@@ -131,13 +134,14 @@ Switch Window, delay
     Length Should Be            ${driver.window_handles}    2
 
 Close window, no tabs open
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
     Close window
 
 Switch window, open multiple, close index
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -160,6 +164,7 @@ Switch window, open multiple, close index
     Should Be Equal             ${driver.title}             Window Acceptance Tests
 
 Title and url
+    [Tags]                      Window    Title    Url
     [Documentation]             Tests for -title and -url keywords
     GoTo                        file://${CURDIR}/../resources/window.html
     ${url}=                     GetUrl
@@ -175,7 +180,7 @@ Set Window Size
 
 Maximize Window
     [Documentation]             Tests for MaximizeWindow keyword
-    [Tags]                      MaximizeWindow
+    [Tags]                      Window    MaximizeWindow
     GoTo                        http://howbigismybrowser.com/
     Sleep                       2                           # wait for browser
     SetConfig                   WindowSize                  550X550
@@ -200,7 +205,7 @@ Maximize Window
     Should be True              ${max_height} > ${height}
 
 Close Other Windows
-    [Tags]                      PROBLEM_IN_SAFARI
+    [Tags]                      Window
     [Documentation]             Close other windows
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     GoTo                        file://${CURDIR}/../resources/window.html
@@ -219,6 +224,7 @@ Close Other Windows
     VerifyText                  Liirum
 
 Self Closing PopUp
+    [Tags]                      Window
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     GoTo                        file://${CURDIR}/../resources/window.html
     Close Others
@@ -230,6 +236,7 @@ Self Closing PopUp
     VerifyText                  Liirum
 
 SwitchWindow 0
+    [Tags]                      Window
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     RunKeywordAndExpectError    QWebValueError: SwitchWindow index starts at 1.         SwitchWindow                0
 

--- a/test/resources/shadow_dom.html
+++ b/test/resources/shadow_dom.html
@@ -19,8 +19,13 @@
                 registerCustomElement( "click-component", "clickTemplate" );
             });
 
-            function myFunction(text) {
-                alert(text);
+            function myFunction() {
+                var x = document.getElementById("hiddenEL");
+                if (x.style.display === "none") {
+                    x.style.display = "block";
+                } else {
+                    x.style.display = "none";
+                }
             }
             </script>
 
@@ -47,13 +52,14 @@
             <click-component id="buttonShadowRoot"></click-component>
             <template id="clickTemplate">
                 <div id="shadowClickTarget">
-                    <button id="myButton" tooltip="Click this" aria-label="Another label" onclick="myFunction('Alert from button')">Click me</button>
+                    <button id="myButton" tooltip="Click this" aria-label="Another label" onclick="myFunction()">Click me</button>
                     <a href="./alert.html">Link</a>
 
                 </div>  
             </template>
             <input type="text" placeholder="username" />
             <span>In both DOM</span>
+            <div style="display:none" id="hiddenEL">This should be hidden</div>
         </body>
     </head>
 


### PR DESCRIPTION
Fixes/changes these issues:
- Automatic Frame search for Safari
  - Own solution to traverse through frames, as switch_to.parent_frame() works differently in Safari than other browsers 
- Window Management for Safari
  - keeps track of open windows, since window_handles returns handles in random order 
- Support for mac COMMAND key
- Removed "not suitable for mac/safari" tags from most tests
- Added Safari to Mac pipeline