### PR TITLE
74 verifyelementtext doesnt highlight the elementtext under test when running the test case

### DIFF
--- a/QWeb/keywords/text.py
+++ b/QWeb/keywords/text.py
@@ -845,6 +845,8 @@ def get_text(
     else:
         web_element = element.get_unique_element_by_xpath(locator, **kwargs)
     text = web_element.text
+    if CONFIG['SearchMode']:
+        element.draw_borders(web_element)
     return util.get_substring(text, **kwargs)
 
 

--- a/test/acceptance/checkbox.robot
+++ b/test/acceptance/checkbox.robot
@@ -57,6 +57,7 @@ Use index anchor
     VerifyCheckboxValue     Blue                    on              2
 
 Checkbox using css 1
+    SetConfig               CssSelectors            on
     VerifyCheckboxStatus    I have a bike           enabled
     VerifyCheckboxStatus    I should be disabled    disabled
     ClickCheckbox           I have a bike           on
@@ -69,8 +70,10 @@ Checkbox using css 1
     VerifyCheckboxValue     I have a car            on
     ClickCheckbox           I have a car            off
     VerifyCheckboxValue     I have a car            off
+    SetConfig               CssSelectors            off
 
 Checkbox using css 2
+    SetConfig               CssSelectors            on
     ClickCheckbox           Red                     on
     ClickCheckbox           Sample text             on
     VerifyCheckboxValue     Sample text             on
@@ -80,6 +83,7 @@ Checkbox using css 2
     ClickCheckbox           Blue                    off
     VerifyCheckboxValue     Red                     on
     VerifyCheckboxValue     Blue                    off
+    SetConfig               CssSelectors            off
 
 Delayed Checkbox
     ClickText               Show checkbox

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -1,6 +1,8 @@
 *** Settings ***
 Documentation                   Tests from element keywords
 Library                         QWeb
+Library    DatabaseLibrary
+Library    OperatingSystem
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
 Test Timeout                    1min
@@ -135,8 +137,6 @@ GetAttributeOK
     # with index using css
     ${attribute}                GetAttribute                input   value        element_type=css    index=5
     should be equal             ${attribute}                Show hidden
-    
-
 
 GetAttributeNOK
     [Tags]                      GetAttribute
@@ -248,3 +248,22 @@ VerifyAttributeNOK
     Run Keyword And Expect Error      QWebElementNotFoundError:*    VerifyAttribute      //button             value                Button2              element_type=css     timeout=2
     # multiple found css
     Run Keyword And Expect Error      QWebValueError:*              VerifyAttribute      button               value                Button2              element_type=css     timeout=2
+
+VerifyElementTextBorders
+    [Tags]                      VerifyElementText    DrawBorders
+    Go To                       file://${CURDIR}/../resources/text.html
+    
+    ${no_border_file}           SetVariable            ${CURDIR}/no_border.png
+    ${with_border_file}         SetVariable            ${CURDIR}/with_border.png
+    Log Screenshot              ${no_border_file}
+
+    ${no_border_image}          Get Binary File        ${no_border_file}
+    ${with_border_image}        Get Binary File        ${no_border_file}
+    Should Be Equal             ${no_border_image}     ${with_border_image}
+
+    Set Config                  SearchMode             Draw
+    Verify Element Text         sentence               more than one
+    Log Screenshot              ${with_border_file}
+    ${with_border_image}        Get Binary File        ${with_border_file}
+
+    Should Not Be Equal         ${no_border_image}     ${with_border_image}

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -1,8 +1,7 @@
 *** Settings ***
 Documentation                   Tests from element keywords
 Library                         QWeb
-Library    DatabaseLibrary
-Library    OperatingSystem
+Library                         OperatingSystem
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
 Test Timeout                    1min


### PR DESCRIPTION
Includes a fix and a new acceptance test in _element.robot_
Placed the test under _element.robot_ since this tests the `draw border feature` and not the `VerifyElementText`