### PR TITLE
Rework GitHub Actions

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -15,69 +15,11 @@ on:
 
 jobs:
   linux_acceptance:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-        browser: [chrome, firefox]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install RFW 3.2.2
-      if: matrix.python-version == '3.7'
-      run: |
-        python -m pip install robotframework==3.2.2
-    - name: Install dependencies
-      run: |
-        sudo apt-get install matchbox scrot
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
-    - name: Display Python version
-      run: |
-        python -c "import sys; print(sys.version)"
-    - name: Display Robot FW version
-      run: |
-        python -m pip show robotframework
-    - name: Typecheck with mypy
-      run: |
-        mypy --show-error-codes QWeb
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Lint with pylint
-      run: |
-        pylint QWeb
-    - name: Test with pytest
-      run: |
-        xvfb-run --auto-servernum pytest -v --junit-xml=unittests.xml --cov=QWeb
-    - name: Acceptance tests Chrome
-      if: matrix.browser == 'chrome'
-      run: |
-        export DISPLAY=:88
-        Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        matchbox-window-manager -use_titlebar no &
-        python -c "import pyautogui; print(pyautogui.size())"
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_LINUX -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Firefox
-      if: matrix.browser == 'firefox'
-      run: |
-        export DISPLAY=:88
-        Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        matchbox-window-manager -use_titlebar no &
-        python -c "import pyautogui; print(pyautogui.size())"
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_LINUX -e PROBLEM_IN_FIREFOX -v BROWSER:Firefox -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Archive Robot Framework Tests Report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v1
-      with:
-        name: acceptance-tests-report-${{ matrix.browser }}-${{ runner.os }}-${{ matrix.python-version }}
-        path: ./output_${{ matrix.browser }}
+    uses: ./.github/workflows/tests-reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["ubuntu-latest"]'
+      browser: '["chrome", "firefox"]'
+      python-version: '["3.7", "3.8", "3.9"]'
+      rfw-322-python: "3.7"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Linux
 
 on:

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   linux_acceptance:
+    name: Linux
     uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   linux_acceptance:
-    uses: ./.github/workflows/tests-reusable.yml
+    uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: MacOS
 
 on:

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: MacOs
+name: MacOS
 
 on:
   push:
@@ -15,6 +15,7 @@ on:
 
 jobs:
   macos_acceptance:
+    name: MacOS
     uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -15,66 +15,12 @@ on:
 
 jobs:
   macos_acceptance:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: [3.8, 3.9]
-        browser: [chrome, safari, edge]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install RFW 3.2.2
-      if: matrix.python-version == '3.9'
-      run: |
-        python -m pip install robotframework==3.2.2
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements_test.txt
-    - name: Display Python version
-      run: |
-        python -c "import sys; print(sys.version)"
-    - name: Display Robot FW version
-      run: |
-        python -m pip show robotframework
-    - name: Typecheck with mypy
-      run: |
-        mypy --show-error-codes QWeb
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Lint with pylint
-      run: |
-        pylint QWeb
-    - name: Test with pytest
-      run: |
-        pytest -v --junit-xml=unittests.xml --cov=QWeb
-    - name: Display screen resolution
-      run: |
-        python -c "import pyautogui; print(pyautogui.size())"
-    - name: Acceptance tests Chrome
-      if: matrix.browser == 'chrome'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Safari
-      if: matrix.browser == 'safari'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_SAFARI -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:safari -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Edge
-      if: matrix.browser == 'edge'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_EDGE -e PROBLEM_IN_MACOS -e RESOLUTION_DEPENDENCY -e FLASK -v BROWSER:edge -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Archive Robot Framework Tests Report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v1
-      with:
-        name: acceptance-tests-report-${{ matrix.browser }}-${{ runner.os }}-${{ matrix.python-version }}
-        path: ./output_${{ matrix.browser }}
+    uses: ./.github/workflows/tests-reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["macos-latest"]'
+      browser: '["chrome", "edge", "safari"]'
+      python-version: '["3.8", "3.9"]'
+      rfw-322-python: "3.8"
+      additional-rfw-parameters: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   macos_acceptance:
-    uses: ./.github/workflows/tests-reusable.yml
+    uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676

--- a/.github/workflows/quality_assurance.yml
+++ b/.github/workflows/quality_assurance.yml
@@ -1,0 +1,118 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Quality Assurance
+
+on: 
+  push:
+    branches: [ master, main ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [ master, main ]
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+    inputs:
+      StaticAnalysis:
+        description: Run Static Analysis
+        type: boolean
+        required: false
+        default: false
+      Linux:
+        description: Run Linux tests
+        type: boolean
+        required: false
+        default: false
+      Windows:
+        description: Run Windows tests
+        type: boolean
+        required: false
+        default: false
+      MacOS:
+        description: Run MacOS tests
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  StaticAnalysis:
+    name: Static Analysis
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      # This job must pass for the test jobs to run 
+      # --> check the execution flag on each step
+      # Is there a better way to skip execution and mark job as passed?
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      uses: actions/checkout@v2
+    - name: Set up Python
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements_test.txt
+
+    - name: Typecheck with mypy
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      run: |
+        mypy --show-error-codes QWeb
+
+    - name: Lint with flake8
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Lint with pylint
+      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
+      run: |
+        pylint QWeb
+
+  Linux:
+    if: ${{ github.event.inputs.Linux == 'true' || github.event.inputs.Linux == null }}
+    needs: StaticAnalysis
+    uses: ./.github/workflows/tests_reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["ubuntu-latest"]'
+      browser: '["chrome", "firefox"]'
+      python-version: '["3.7", "3.8", "3.9"]'
+      rfw-322-python: "3.7"
+
+  Windows:
+    if: ${{ github.event.inputs.Windows == 'true' || github.event.inputs.Windows == null}}
+    needs: StaticAnalysis
+    uses: ./.github/workflows/tests_reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["windows-latest"]'
+      browser: '["chrome", "edge", "firefox"]'
+      python-version: '["3.9", "3.10"]'
+      rfw-322-python: "3.9"
+      additional-rfw-parameters: "-e FLASK"
+
+  MacOS:
+    if: ${{ github.event.inputs.MacOS == 'true' || github.event.inputs.MacOS == null }}
+    needs: StaticAnalysis
+    uses: ./.github/workflows/tests_reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["macos-latest"]'
+      browser: '["chrome", "edge", "safari"]'
+      python-version: '["3.8", "3.9"]'
+      rfw-322-python: "3.8"
+      additional-rfw-parameters: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/quality_assurance.yml
+++ b/.github/workflows/quality_assurance.yml
@@ -12,33 +12,9 @@ on:
     branches: [ master, main ]
     paths-ignore:
       - '**.md'
-  workflow_dispatch:
-    inputs:
-      StaticAnalysis:
-        description: Run Static Analysis
-        type: boolean
-        required: false
-        default: false
-      Linux:
-        description: Run Linux tests
-        type: boolean
-        required: false
-        default: false
-      Windows:
-        description: Run Windows tests
-        type: boolean
-        required: false
-        default: false
-      MacOS:
-        description: Run MacOS tests
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   StaticAnalysis:
-    name: Static Analysis
-
     runs-on: ubuntu-latest
 
     steps:
@@ -78,41 +54,3 @@ jobs:
       if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       run: |
         pylint QWeb
-
-  Linux:
-    if: ${{ github.event.inputs.Linux == 'true' || github.event.inputs.Linux == null }}
-    needs: StaticAnalysis
-    uses: ./.github/workflows/tests_reusable.yml
-    with:
-      # arrays for matrices must be given as string for json parsing
-      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["ubuntu-latest"]'
-      browser: '["chrome", "firefox"]'
-      python-version: '["3.7", "3.8", "3.9"]'
-      rfw-322-python: "3.7"
-
-  Windows:
-    if: ${{ github.event.inputs.Windows == 'true' || github.event.inputs.Windows == null}}
-    needs: StaticAnalysis
-    uses: ./.github/workflows/tests_reusable.yml
-    with:
-      # arrays for matrices must be given as string for json parsing
-      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["windows-latest"]'
-      browser: '["chrome", "edge", "firefox"]'
-      python-version: '["3.9", "3.10"]'
-      rfw-322-python: "3.9"
-      additional-rfw-parameters: "-e FLASK"
-
-  MacOS:
-    if: ${{ github.event.inputs.MacOS == 'true' || github.event.inputs.MacOS == null }}
-    needs: StaticAnalysis
-    uses: ./.github/workflows/tests_reusable.yml
-    with:
-      # arrays for matrices must be given as string for json parsing
-      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["macos-latest"]'
-      browser: '["chrome", "edge", "safari"]'
-      python-version: '["3.8", "3.9"]'
-      rfw-322-python: "3.8"
-      additional-rfw-parameters: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Quality Assurance
+name: Static Analysis
 
 on: 
   push:
@@ -19,31 +19,23 @@ jobs:
 
     steps:
     - name: Checkout
-      # This job must pass for the test jobs to run 
-      # --> check the execution flag on each step
-      # Is there a better way to skip execution and mark job as passed?
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       uses: actions/checkout@v2
     - name: Set up Python
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
 
     - name: Install dependencies
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements_test.txt
 
     - name: Typecheck with mypy
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       run: |
         mypy --show-error-codes QWeb
 
     - name: Lint with flake8
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -51,6 +43,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Lint with pylint
-      if: ${{ github.event.inputs.StaticAnalysis == 'true' || github.event.inputs.StaticAnalysis == null }}
       run: |
         pylint QWeb

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -68,8 +68,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -r requirements_test.txt        
-        pip install QWeb
+        pip install -r requirements_test.txt
 
     - name: Display Python version
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -1,0 +1,92 @@
+name: Tests Reusable
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Stringified JSON object listing target os'
+        required: true
+        type: string
+      browser:
+        description: 'Stringified JSON object listing target browsers'
+        required: true
+        type: string
+      python-version:
+        description: 'Stringified JSON object listing target Python versions'
+        required: true
+        type: string
+      rfw-322-python:
+        description: Python version which will be used with RFW 3.2.2
+        required: true
+        type: string
+      additional-rfw-parameters:
+        description: Execution parameters which will be added to RFW execution
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  Tests:
+    name: ${{ matrix.python-version }} / ${{ matrix.browser }}
+    
+    strategy:
+      matrix:
+        os: ${{fromJson(inputs.os)}}
+        browser: ${{fromJson(inputs.browser)}}
+        python-version: ${{fromJson(inputs.python-version)}}
+        
+    runs-on: ${{ matrix.os }}
+    env:
+      # Used in Linux tests for windowing
+      DISPLAY: :88
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Linux windowing
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install matchbox scrot
+        Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
+        matchbox-window-manager -use_titlebar no &
+        pip install python-xlib
+
+    - name: Install RFW 3.2.2
+      if: matrix.python-version == inputs.rfw-322-python
+      run: |
+        python -m pip install robotframework==3.2.2
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements_test.txt        
+        pip install QWeb
+    - name: Display Python version
+      run: |
+        python -c "import sys; print(sys.version)"
+    - name: Display Robot FW version
+      run: |
+        python -m pip show robotframework
+    - name: Display screen resolution
+      run: |
+        python -c "import pyautogui; print(pyautogui.size())"
+
+    - name: Unit tests
+      run: |
+        pytest -v --junit-xml=unittests.xml --cov=QWeb
+
+    - name: Acceptance tests
+      run: |
+        python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+    
+    - name: Archive Robot Framework Tests Report
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: test-report-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}
+        path: ./output_${{ matrix.browser }}

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -1,3 +1,6 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
 name: Tests Reusable
 
 on:
@@ -47,6 +50,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Setup Linux windowing
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -59,19 +63,22 @@ jobs:
       if: matrix.python-version == inputs.rfw-322-python
       run: |
         python -m pip install robotframework==3.2.2
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements_test.txt        
         pip install QWeb
+
     - name: Display Python version
       run: |
         python -c "import sys; print(sys.version)"
+
     - name: Display Robot FW version
       run: |
         python -m pip show robotframework
+
     - name: Display screen resolution
       run: |
         python -c "import pyautogui; print(pyautogui.size())"

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Windows
 
 on:

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   windows_acceptance:
+    name: Windows
     uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -15,66 +15,12 @@ on:
 
 jobs:
   windows_acceptance:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [3.9, '3.10']
-        browser: [chrome, firefox, edge]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install RFW 3.2.2
-      if: matrix.python-version == '3.9'
-      run: |
-        python -m pip install robotframework==3.2.2
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements_test.txt
-    - name: Display Python version
-      run: |
-        python -c "import sys; print(sys.version)"
-    - name: Display Robot FW version
-      run: |
-        python -m pip show robotframework
-    - name: Typecheck with mypy
-      run: |
-        mypy --show-error-codes QWeb
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Lint with pylint
-      run: |
-        pylint QWeb
-    - name: Test with pytest
-      run: |
-        pytest -v --junit-xml=unittests.xml --cov=QWeb
-    - name: Display screen resolution
-      run: |
-        python -c "import pyautogui; print(pyautogui.size())"
-    - name: Acceptance tests Chrome
-      if: matrix.browser == 'chrome'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_WINDOWS -e FLASK -v BROWSER:Chrome -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Firefox
-      if: matrix.browser == 'firefox'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_WINDOWS -e FLASK -e PROBLEM_IN_FIREFOX -v BROWSER:Firefox -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Acceptance tests Edge
-      if: matrix.browser == 'edge'
-      run: |
-        python -m robot --exitonfailure -e jailed -e PROBLEM_IN_EDGE -e PROBLEM_IN_WINDOWS -e FLASK -v BROWSER:edge -d output_${{ matrix.browser }} --name QWeb -b debug.txt --consolecolors ansi test/acceptance
-    - name: Archive Robot Framework Tests Report
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v1
-      with:
-        name: acceptance-tests-report-${{ matrix.browser }}-${{ runner.os }}-${{ matrix.python-version }}
-        path: ./output_${{ matrix.browser }}
+    uses: ./.github/workflows/tests-reusable.yml
+    with:
+      # arrays for matrices must be given as string for json parsing
+      # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
+      os: '["windows-latest"]'
+      browser: '["chrome", "edge", "firefox"]'
+      python-version: '["3.9", "3.10"]'
+      rfw-322-python: "3.9"
+      additional-rfw-parameters: "-e FLASK"

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   windows_acceptance:
-    uses: ./.github/workflows/tests-reusable.yml
+    uses: ./.github/workflows/tests_reusable.yml
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676


### PR DESCRIPTION
Split test workflows into different files, _static_analysis.yml_, _[os]\_acceptance.yml_ and _tests_reusable.yml_

_static_analysis.yml_ runs type checking and linting, these used to be part of _[os]\_acceptance.yml_ and were ran 18 times instead of once.
_[os]\_acceptance.yml_ now only contain matrix variable definitions which are passed to _tests_reusable.yml_
_tests_reusable.yml_ contains generic unit and acceptance test workflow which works on all OS platforms (though limited to X-latest OS:s)