### PR TITLE
Fixing get_item_using_anchor

### DIFF
--- a/QWeb/internal/text.py
+++ b/QWeb/internal/text.py
@@ -311,8 +311,8 @@ def get_item_using_anchor(text: str, anchor: str, **kwargs) -> Optional[WebEleme
         else:
             web_elements = elements
     if web_elements:
+        correct = _get_correct_element(web_elements, str(anchor), **kwargs)
         if CONFIG['SearchMode']:
-            correct = _get_correct_element(web_elements, str(anchor), **kwargs)
             element.draw_borders(correct)
         return correct
     no_raise = util.par2bool(kwargs.get('allow_non_existent', False))


### PR DESCRIPTION
Issue: Click Item keyword fails with error message "UnboundLocalError: local variable 'correct' referenced before assignment" if SearchMode is set to None with RF built-in variable ${NONE}.
Fix: Assigning value to var 'correct' before ifCONFIG['SearchMode'] block. 