### PR TITLE
Browserstack capabilities change

### DIFF
--- a/QWeb/internal/browser/bs_desktop.py
+++ b/QWeb/internal/browser/bs_desktop.py
@@ -3,6 +3,7 @@ import os
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
+from typing import Any
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 from QWeb.internal import browser, exceptions
@@ -25,12 +26,12 @@ OS: dict[str, str] = {
 }
 
 
-def open_browser(bs_browser: str, project_name: str, run_id: str, **kwargs: str) -> WebDriver:
+def open_browser(bs_browser: str, project_name: str, run_id: str, **kwargs: Any) -> WebDriver:
     bs_key = BuiltIn().get_variable_value('${APIKEY}') or os.environ.get('bskey')
     bs_user = BuiltIn().get_variable_value('${USERNAME}') or os.environ.get('bsuser')
     bs_os = BuiltIn().get_variable_value('${BSOS}') or 'windows'
 
-    desired_caps = {
+    desired_caps:dict = {
         'bstack:options': {
             "buildName": project_name,
             "projectName": project_name,

--- a/QWeb/internal/browser/bs_desktop.py
+++ b/QWeb/internal/browser/bs_desktop.py
@@ -10,41 +10,49 @@ from QWeb.internal import browser, exceptions
 NAMES: dict[str, tuple[str, str]] = {
     # Default  versions for different browsers.
     'chrome': ('Chrome', 'latest'),
-    'ie': ('IE', '11'),
-    'internet explorer': ('IE', '11'),
-    'edge': ('Edge', '18.0'),
-    'firefox': ('Firefox', '66.0'),
-    'ff': ('Firefox', '66.0'),
-    'safari': ('Safari', '13.0')
+    'ie': ('IE', 'latest'),
+    'internet explorer': ('IE', 'latest'),
+    'edge': ('Edge', 'latest'),
+    'firefox': ('Firefox', 'latest'),
+    'ff': ('Firefox', 'latest'),
+    'safari': ('Safari', '15.3')
 }
 
 OS: dict[str, str] = {
     # Default versions for Windows and OSX.
-    'osx': 'Catalina',
+    'osx': '"Big Sur',
     'windows': '10'
 }
 
 
-def open_browser(bs_browser: str, project_name: str, run_id: str) -> WebDriver:
+def open_browser(bs_browser: str, project_name: str, run_id: str, **kwargs: str) -> WebDriver:
     bs_key = BuiltIn().get_variable_value('${APIKEY}') or os.environ.get('bskey')
     bs_user = BuiltIn().get_variable_value('${USERNAME}') or os.environ.get('bsuser')
     bs_os = BuiltIn().get_variable_value('${BSOS}') or 'windows'
 
     desired_caps = {
-        'build': project_name,
-        'project': project_name,
-        'name': run_id,
-        'os': bs_os,
-        'resolution': BuiltIn().get_variable_value('${BSRESOLUTION}') or '1920x1080',
-        'browserstack.local': BuiltIn().get_variable_value('${BSLOCAL}') or 'false',
-        'browserstack.localIdentifier': BuiltIn().get_variable_value('${BSLOCALID}') or '',
-        'os_version': BuiltIn().get_variable_value('${BSOSVERSION}') or OS[bs_os.lower()],
-        'browser': BuiltIn().get_variable_value('${BROWSER}') or NAMES[bs_browser][0],
-        'browser_version': BuiltIn().get_variable_value('${BROWSERVERSION}') or NAMES[bs_browser][1]
+        'bstack:options': {
+            "buildName": project_name,
+            "projectName": project_name,
+            "sessionName": run_id,
+            'os': bs_os,
+            'osVersion': BuiltIn().get_variable_value('${BSOSVERSION}') or OS[bs_os.lower()],
+            'resolution': BuiltIn().get_variable_value('${BSRESOLUTION}') or '1920x1080',
+            "local": BuiltIn().get_variable_value('${BSLOCAL}') or "false",
+            "localIdentifier": BuiltIn().get_variable_value('${BSLOCALID}') or '',
+            **kwargs,
+        },
+
+        'browserName': BuiltIn().get_variable_value('${BROWSER}') or NAMES[bs_browser][0],
+        'browserVersion': BuiltIn().get_variable_value('${BROWSERVERSION}') or NAMES[bs_browser][1]
     }
 
+    # handle issue where any, even empty value in localIdentifier turns local to true
+    if desired_caps["bstack:options"]["local"] == 'false':
+        del desired_caps["bstack:options"]["localIdentifier"]
+
     try:
-        executor_url = 'https://{}:{}@hub-cloud.browserstack.com/wd/hub'.format(bs_user, bs_key)
+        executor_url = f'https://{bs_user}:{bs_key}@hub-cloud.browserstack.com/wd/hub'
         driver = webdriver.Remote(command_executor=executor_url, desired_capabilities=desired_caps)
         logger.info(f'BrowserStack session ID: {driver.session_id}', also_console=True)
     except WebDriverException as e:

--- a/QWeb/internal/browser/bs_desktop.py
+++ b/QWeb/internal/browser/bs_desktop.py
@@ -46,6 +46,7 @@ def open_browser(bs_browser: str, project_name: str, run_id: str) -> WebDriver:
     try:
         executor_url = 'https://{}:{}@hub-cloud.browserstack.com/wd/hub'.format(bs_user, bs_key)
         driver = webdriver.Remote(command_executor=executor_url, desired_capabilities=desired_caps)
+        logger.info(f'BrowserStack session ID: {driver.session_id}', also_console=True)
     except WebDriverException as e:
         logger.error(e)
         raise exceptions.QWebException('Incorrect Browserstack capabilities.')

--- a/QWeb/internal/browser/bs_mobile.py
+++ b/QWeb/internal/browser/bs_mobile.py
@@ -2,12 +2,13 @@ import os
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
+from typing import Any
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 from QWeb.internal import browser, exceptions
 
 
-def open_browser(bs_device: str, project_name: str, run_id: str, **kwargs: str) -> WebDriver:
+def open_browser(bs_device: str, project_name: str, run_id: str, **kwargs: Any) -> WebDriver:
 
     desired_cap = {
         'bstack:options': {

--- a/QWeb/internal/browser/bs_mobile.py
+++ b/QWeb/internal/browser/bs_mobile.py
@@ -24,6 +24,7 @@ def open_browser(bs_device: str, project_name: str, run_id: str) -> WebDriver:
         driver = webdriver.Remote(
             command_executor='http://{}:{}@hub.browserstack.com:80/wd/hub'.format(bs_user, bs_key),
             desired_capabilities=desired_cap)
+        logger.info(f'BrowserStack session ID: {driver.session_id}', also_console=True)
     except WebDriverException as e:
         logger.error(e)
         raise exceptions.QWebException('Incorrect Browserstack capabilities.')

--- a/QWeb/internal/browser/bs_mobile.py
+++ b/QWeb/internal/browser/bs_mobile.py
@@ -7,23 +7,33 @@ from robot.libraries.BuiltIn import BuiltIn
 from QWeb.internal import browser, exceptions
 
 
-def open_browser(bs_device: str, project_name: str, run_id: str) -> WebDriver:
+def open_browser(bs_device: str, project_name: str, run_id: str, **kwargs: str) -> WebDriver:
+
     desired_cap = {
-        'build': project_name,
-        'project': project_name,
-        'name': run_id,
-        'device': bs_device,
-        'real_mobile': 'true',
-        'browserstack.local': BuiltIn().get_variable_value('${BSLOCAL}') or 'false',
-        'browserstack.localIdentifier': BuiltIn().get_variable_value('${BSLOCALID}') or ''
+        'bstack:options': {
+            "buildName": project_name,
+            "projectName": project_name,
+            "sessionName": run_id,
+            "deviceName": bs_device,
+            "realMobile": "true",
+            "local": BuiltIn().get_variable_value('${BSLOCAL}') or "false",
+            "localIdentifier": BuiltIn().get_variable_value('${BSLOCALID}') or '',
+            **kwargs,
+        }
     }
+
+    # handle issue where any, even empty value in localIdentifier turns local to true
+    if desired_cap["bstack:options"]["local"] == 'false':
+        del desired_cap["bstack:options"]["localIdentifier"]
+
     bs_key = BuiltIn().get_variable_value('${APIKEY}') or os.environ.get('bskey')
     bs_user = BuiltIn().get_variable_value('${USERNAME}') or os.environ.get('bsuser')
 
     try:
         driver = webdriver.Remote(
-            command_executor='http://{}:{}@hub.browserstack.com:80/wd/hub'.format(bs_user, bs_key),
-            desired_capabilities=desired_cap)
+                 command_executor=f'http://{bs_user}:{bs_key}@hub.browserstack.com:80/wd/hub',
+                 desired_capabilities=desired_cap)
+
         logger.info(f'BrowserStack session ID: {driver.session_id}', also_console=True)
     except WebDriverException as e:
         logger.error(e)

--- a/QWeb/keywords/browser.py
+++ b/QWeb/keywords/browser.py
@@ -160,9 +160,9 @@ def open_browser(url: str, browser_alias: str, options: Optional[str] = None, **
     if provider in ('bs', 'browserstack'):
         bs_device = BuiltIn().get_variable_value('${DEVICE}')
         if not bs_device and b_lower in bs_desktop.NAMES:
-            driver = bs_desktop.open_browser(b_lower, bs_project_name, bs_run_id)
+            driver = bs_desktop.open_browser(b_lower, bs_project_name, bs_run_id, **kwargs)
         elif bs_device:
-            driver = bs_mobile.open_browser(bs_device, bs_project_name, bs_run_id)
+            driver = bs_mobile.open_browser(bs_device, bs_project_name, bs_run_id, **kwargs)
         else:
             raise exceptions.QWebException('Unknown browserstack browser {}'.format(browser_alias))
     else:


### PR DESCRIPTION
- change from legacy format to W3C.
-  Also now we support rest of browserstack capabilities as kwargs
- Updated browser versions to 'latest'
- log session id in openbrowser