### PR TITLE
Improvements-to-acceptance-test-resiliency

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ disable ]  #master ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ disable ]  #master ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -18,7 +18,7 @@ jobs:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
       os: '["macos-latest"]'
-      browser: '["chrome", "edge", "safari"]'
-      python-version: '["3.8", "3.9"]'
+      browser: '["safari"]'  #'["chrome", "edge", "safari"]'
+      python-version: '["3.8"]'  #", "3.9"]'
       rfw-322-python: "3.8"
       rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -21,4 +21,4 @@ jobs:
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.8", "3.9"]'
       rfw-322-python: "3.8"
-      additional-rfw-parameters: "-e RESOLUTION_DEPENDENCY -e FLASK"
+      rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -18,7 +18,7 @@ jobs:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
       os: '["macos-latest"]'
-      browser: '["safari"]'  #'["chrome", "edge", "safari"]'
-      python-version: '["3.8"]'  #", "3.9"]'
+      browser: '["chrome", "edge", "safari"]'
+      python-version: '["3.8", "3.9"]'
       rfw-322-python: "3.8"
       rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ disable ]  #master, main ]
+    branches: [ master, main ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.9
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ master, main ]
+    branches: [ disable ]  #master, main ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -91,13 +91,13 @@ jobs:
     - name: Acceptance tests
       id: initial-acceptance-tests
       continue-on-error: true
-      timeout-minutes: 45
+      timeout-minutes: 30
       run: |
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
     - name: Rerun failed acceptance tests
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
-      timeout-minutes: 45
+      timeout-minutes: 30
       run: |
         python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
         

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -96,14 +96,14 @@ jobs:
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Rerun failed acceptance tests
-      if: ${ steps.initial-acceptance-tests.outcome == 'failure' }
+      if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
       timeout-minutes: 45
       run: |
         python -m robot --rerunfailed output_${{ matrix.browser }}/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
-      if: ${ steps.initial-acceptance-tests.outcome == 'failure' }
+      if: steps.initial-acceptance-tests.outcome == 'failure'
       run: |
         python -m rebot --merge output_${{ matrix.browser }}/output.xml output_${{ matrix.browser }}/rerun.xml
         mv log.html output_${{ matrix.browser }}/log.html

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -99,7 +99,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 45
       run: |
-        python -m robot --rerunfailed first/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -22,8 +22,13 @@ on:
         description: Python version which will be used with RFW 3.2.2
         required: true
         type: string
+      rfw-exclude-tags:
+        description: Tag exclusions which will be added to RFW execution. For example  "-e FLASK"
+        required: false
+        default: ""
+        type: string
       additional-rfw-parameters:
-        description: Execution parameters which will be added to RFW execution
+        description: Execution parameters which will be added to RFW execution. For example "-v customvar:somevalue"
         required: false
         default: ""
         type: string
@@ -93,7 +98,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 30
       run: |
-        python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} ${{ inputs.rfw-exclude-tags }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
     - name: Rerun failed acceptance tests
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -105,7 +105,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 30
       run: |
-        python -m robot --rerunfailedsuites result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailedsuites result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
 
     # robot returns amount of failed tests, github considers it as a failure and stops step execution
     # -> result merging needs a separate step
@@ -113,17 +113,7 @@ jobs:
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
       run: |
-        mv rerun/rerun.xml result/rerun.xml
-        python -m robot.rebot --merge result/output.xml result/rerun.xml
-
-    # robot.rebot returns amount of failed tests, github considers it as a failure and stops step execution
-    # -> result moving needs a separate step
-    - name: Move merged test results
-      if: steps.initial-acceptance-tests.outcome == 'failure'
-      run: |
-        rm result/*.html
-        mv log.html result/log.html
-        mv report.html result/report.html
+        python -m robot.rebot --merge -d result result/output.xml result/rerun.xml
     
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'
       run: |
-        python -m rebot --merge output_${{ matrix.browser }}/output.xml output_${{ matrix.browser }}/rerun.xml
+        python -m robot.rebot --merge output_${{ matrix.browser }}/output.xml output_${{ matrix.browser }}/rerun.xml
         mv log.html output_${{ matrix.browser }}/log.html
         mv report.html output_${{ matrix.browser }}/report.html
     

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -109,10 +109,14 @@ jobs:
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'
+      continue-on-error: true
       run: |
-        python -m robot.rebot --merge result/output.xml rerun/rerun.xml
-        
         mv rerun/rerun.xml result/rerun.xml
+        python -m robot.rebot --merge result/output.xml result/rerun.xml
+        
+    - name: Move merged test results
+      if: steps.initial-acceptance-tests.outcome == 'failure'
+      run: |
         rm result/*.html
         mv log.html result/log.html
         mv report.html result/report.html

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -106,14 +106,18 @@ jobs:
       timeout-minutes: 30
       run: |
         python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
-        
-    - name: Merge rerun test results
+
+    # robot returns amount of failed tests, github considers it as a failure and stops step execution
+    # -> result merging needs a separate step
+    - name: Merge rerun test results  
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
       run: |
         mv rerun/rerun.xml result/rerun.xml
         python -m robot.rebot --merge result/output.xml result/rerun.xml
         
+    # robot.rebot returns amount of failed tests, github considers it as a failure and stops step execution
+    # -> result moving needs a separate step
     - name: Move merged test results
       if: steps.initial-acceptance-tests.outcome == 'failure'
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -113,7 +113,7 @@ jobs:
         python -m robot.rebot --merge result/output.xml rerun/rerun.xml
         
         mv rerun/rerun.xml result/rerun.xml
-        del result/*.html
+        rm result/*.html
         mv log.html result/log.html
         mv report.html result/report.html
     

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -33,6 +33,8 @@ jobs:
     name: ${{ matrix.python-version }} / ${{ matrix.browser }}
     
     strategy:
+      # MacOS & Windows tests often fail due to webdriver errors
+      fail-fast: false
       matrix:
         os: ${{fromJson(inputs.os)}}
         browser: ${{fromJson(inputs.browser)}}
@@ -87,8 +89,11 @@ jobs:
         pytest -v --junit-xml=unittests.xml --cov=QWeb
 
     - name: Acceptance tests
+      timeout-minutes: 45
       run: |
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m rebot --merge output.xml rerun.xml
     
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -93,25 +93,29 @@ jobs:
       continue-on-error: true
       timeout-minutes: 45
       run: |
-        python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
-        
+        python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
     - name: Rerun failed acceptance tests
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
       timeout-minutes: 45
       run: |
-        python -m robot --rerunfailed output_${{ matrix.browser }}/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed first/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'
       run: |
-        python -m robot.rebot --merge output_${{ matrix.browser }}/output.xml output_${{ matrix.browser }}/rerun.xml
-        mv log.html output_${{ matrix.browser }}/log.html
-        mv report.html output_${{ matrix.browser }}/report.html
+        
+        python -m robot.rebot --merge result/output.xml rerun/rerun.xml
+        
+        mv rerun/rerun.xml result/rerun.xml
+        
+        del result/*.html
+        mv log.html result/log.html
+        mv report.html result/report.html
     
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}
       uses: actions/upload-artifact@v1
       with:
         name: test-report-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}
-        path: ./output_${{ matrix.browser }}
+        path: ./result

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -111,7 +111,6 @@ jobs:
     # -> result merging needs a separate step
     - name: Merge rerun test results  
       if: steps.initial-acceptance-tests.outcome == 'failure'
-      continue-on-error: true
       run: |
         python -m robot.rebot --merge -d result result/output.xml result/rerun.xml
     

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -92,6 +92,11 @@ jobs:
       timeout-minutes: 45
       run: |
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        
+    - name: Rerun failed acceptance tests
+      if: ${{ failure() }}
+      timeout-minutes: 45
+      run: |
         python -m robot --rerunfailed output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         python -m rebot --merge output.xml rerun.xml
     

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -105,7 +105,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 30
       run: |
-        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -99,6 +99,7 @@ jobs:
       timeout-minutes: 30
       run: |
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} ${{ inputs.rfw-exclude-tags }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d result --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+    
     - name: Rerun failed acceptance tests
       if: steps.initial-acceptance-tests.outcome == 'failure'
       continue-on-error: true
@@ -109,11 +110,9 @@ jobs:
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'
       run: |
-        
         python -m robot.rebot --merge result/output.xml rerun/rerun.xml
         
         mv rerun/rerun.xml result/rerun.xml
-        
         del result/*.html
         mv log.html result/log.html
         mv report.html result/report.html

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -105,7 +105,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 30
       run: |
-        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailedsuites result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
 
     # robot returns amount of failed tests, github considers it as a failure and stops step execution
     # -> result merging needs a separate step
@@ -115,7 +115,7 @@ jobs:
       run: |
         mv rerun/rerun.xml result/rerun.xml
         python -m robot.rebot --merge result/output.xml result/rerun.xml
-        
+
     # robot.rebot returns amount of failed tests, github considers it as a failure and stops step execution
     # -> result moving needs a separate step
     - name: Move merged test results

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -99,7 +99,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 30
       run: |
-        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed result/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -v BROWSER:${{ matrix.browser }} -d rerun -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -51,10 +51,10 @@ jobs:
       DISPLAY: :88
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -100,7 +100,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 45
       run: |
-        python -m robot --rerunfailed output_${{ matrix.browser }}/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        python -m robot --rerunfailed output_${{ matrix.browser }}/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Merge rerun test results
       if: steps.initial-acceptance-tests.outcome == 'failure'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -89,16 +89,25 @@ jobs:
         pytest -v --junit-xml=unittests.xml --cov=QWeb
 
     - name: Acceptance tests
+      id: initial-acceptance-tests
+      continue-on-error: true
       timeout-minutes: 45
       run: |
         python -m robot --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
         
     - name: Rerun failed acceptance tests
-      if: ${{ failure() }}
+      if: ${ steps.initial-acceptance-tests.outcome == 'failure' }
+      continue-on-error: true
       timeout-minutes: 45
       run: |
-        python -m robot --rerunfailed output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
-        python -m rebot --merge output.xml rerun.xml
+        python -m robot --rerunfailed output_${{ matrix.browser }}/output.xml -o rerun.xml --exitonfailure ${{ inputs.additional-rfw-parameters }} -e jailed -e PROBLEM_IN_${{ runner.os }} -e PROBLEM_IN_${{ matrix.browser }} -v BROWSER:${{ matrix.browser }} -d output_${{ matrix.browser }} --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }} -b debug.txt --consolecolors ansi test/acceptance
+        
+    - name: Merge rerun test results
+      if: ${ steps.initial-acceptance-tests.outcome == 'failure' }
+      run: |
+        python -m rebot --merge output_${{ matrix.browser }}/output.xml output_${{ matrix.browser }}/rerun.xml
+        mv log.html output_${{ matrix.browser }}/log.html
+        mv report.html output_${{ matrix.browser }}/report.html
     
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ master ]
+    branches: [ disable ]  #master ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ disable ]  #master ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -21,4 +21,5 @@ jobs:
       browser: '["chrome", "edge", "firefox"]'
       python-version: '["3.9", "3.10"]'
       rfw-322-python: "3.9"
-      additional-rfw-parameters: "-e FLASK"
+      rfw-exclude-tags: "-e FLASK"
+      

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -80,8 +80,6 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                         raise QWebBrowserError(e)  # pylint: disable=W0707
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
-                    if isinstance(e, WebDriverException):
-                        logger.info(f'Derived WebDriverException class name:\n{e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -80,7 +80,8 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                         raise QWebBrowserError(e)  # pylint: disable=W0707
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
-                    logger.info(f'Derived exception class name: {e.__class__.__name__}')
+                    if isinstance(e, WebDriverException):
+                        logger.info(f'Derived WebDriverException class: {e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -144,8 +144,8 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                     err = QWebDriverError  # type: ignore[assignment]
                     msg = wde  # type: ignore[assignment]
                 else:
-                    logger.info(f'Raising from timeout_decorator_actions.\n',
-                        f'Original exception class name: {wde.__class__.__name__}')
+                    logger.info(f'Raising from timeout_decorator_actions.')
+                    logger.info(f'Original exception class name: {wde.__class__.__name__}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -144,8 +144,8 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                     err = QWebDriverError  # type: ignore[assignment]
                     msg = wde  # type: ignore[assignment]
                 else:
-                    logger.info(f'Raising from timeout_decorator_actions.')
-                    logger.info(f'Original exception class name: {wde.__class__.__name__}')
+                    logger.info(f'Raising from timeout_decorator_actions.\n',
+                        f'Original exception class name: {wde.__class__.__name__}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -146,7 +146,6 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                 else:
                     logger.info(f'Raising from timeout_decorator_actions.')
                     logger.info(f'Original exception class name: {wde.__class__.__name__}')
-                    logger.info(f'Stacktrace:\n{wde.stacktrace}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -144,6 +144,8 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                     err = QWebDriverError  # type: ignore[assignment]
                     msg = wde  # type: ignore[assignment]
                 else:
+                    logger.info(f'Raising from timeout_decorator_actions.\n',
+                        f'Original exception class name: {wde.__class__.__name__}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -146,6 +146,7 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                 else:
                     logger.info(f'Raising from timeout_decorator_actions.')
                     logger.info(f'Original exception class name: {wde.__class__.__name__}')
+                    logger.info(f'Stacktrace:\n{wde.stacktrace}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -81,7 +81,7 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
                     if isinstance(e, WebDriverException):
-                        logger.info(f'Derived WebDriverException class name:\n{e.__class__.__name__}')
+                        logger.info(f'Derived WebDriverException class: {e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -80,6 +80,8 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                         raise QWebBrowserError(e)  # pylint: disable=W0707
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
+                    if isinstance(e, WebDriverException):
+                        logger.info(f'Derived WebDriverException class name:\n{e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -81,7 +81,7 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
                     if isinstance(e, WebDriverException):
-                        logger.info(f'Derived WebDriverException class: {e.__class__.__name__}')
+                        logger.info(f'Derived WebDriverException class name:\n{e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -80,8 +80,7 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                         raise QWebBrowserError(e)  # pylint: disable=W0707
                     logger.info('From timeout decorator: Webdriver exception. Retrying..')
                     logger.info(e)
-                    if isinstance(e, WebDriverException):
-                        logger.info(f'Derived WebDriverException class: {e.__class__.__name__}')
+                    logger.info(f'Derived exception class name: {e.__class__.__name__}')
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -144,8 +144,6 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                     err = QWebDriverError  # type: ignore[assignment]
                     msg = wde  # type: ignore[assignment]
                 else:
-                    logger.info(f'Raising from timeout_decorator_actions.\n',
-                        f'Original exception class name: {wde.__class__.__name__}')
                     raise QWebDriverError(wde)  # pylint: disable=W0707
         if msg:
             raise err(msg)  # type: ignore[misc]

--- a/test/acceptance/ClickItem.robot
+++ b/test/acceptance/ClickItem.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
-Test Timeout        1min
+Test Timeout        10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/ClickItem.robot
+++ b/test/acceptance/ClickItem.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
-Test Timeout        20 seconds
+Test Timeout        30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/ClickItem.robot
+++ b/test/acceptance/ClickItem.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
-Test Timeout        10 seconds
+Test Timeout        20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/ClickItem.robot
+++ b/test/acceptance/ClickItem.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -35,7 +35,7 @@ Filtering based on modal
 
     # Filter by modal
     ${prev}=                 SetConfig                     IsModalXPath                  //div[@id="modal_element"]
-    ${found}=                IsText                        Accordion Element 1
+    ${found}=                IsText                        Accordion Element 1           timeout=1
     Should Not Be True       ${found}
 
     SetConfig                IsModalXPath                  ${prev}       

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/accordions_and_modals.html
 Suite Teardown      CloseBrowser
-Test Timeout        1min
+Test Timeout        10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/accordions_and_modals.html
 Suite Teardown      CloseBrowser
-Test Timeout        20 seconds
+Test Timeout        30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/accordions_and_modals.html
 Suite Teardown      CloseBrowser
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -35,7 +35,7 @@ Filtering based on modal
 
     # Filter by modal
     ${prev}=                 SetConfig                     IsModalXPath                  //div[@id="modal_element"]
-    ${found}=                IsText                        Accordion Element 1           timeout=1
+    ${found}=                IsText                        Accordion Element 1
     Should Not Be True       ${found}
 
     SetConfig                IsModalXPath                  ${prev}       

--- a/test/acceptance/accordion.robot
+++ b/test/acceptance/accordion.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
 Test Setup          GoTo    file://${CURDIR}/../resources/accordions_and_modals.html
 Suite Teardown      CloseBrowser
-Test Timeout        10 seconds
+Test Timeout        20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/alert.robot
+++ b/test/acceptance/alert.robot
@@ -3,7 +3,7 @@ Documentation     Tests for handling of alerts
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/alert.html    ${BROWSER}   --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/alert.robot
+++ b/test/acceptance/alert.robot
@@ -3,7 +3,7 @@ Documentation     Tests for handling of alerts
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/alert.html    ${BROWSER}   --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/alert.robot
+++ b/test/acceptance/alert.robot
@@ -3,7 +3,7 @@ Documentation     Tests for handling of alerts
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/alert.html    ${BROWSER}   --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/alert.robot
+++ b/test/acceptance/alert.robot
@@ -3,7 +3,7 @@ Documentation     Tests for handling of alerts
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/alert.html    ${BROWSER}   --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/browser.robot
+++ b/test/acceptance/browser.robot
@@ -3,7 +3,7 @@ Documentation     Tests for opening browsers
 Library           OperatingSystem
 Library           QWeb
 Test Setup        Open Browser And Wait A Bit
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 Suite Teardown    Close All Browsers
 
 *** Variables ***
@@ -25,7 +25,6 @@ Close All Browsers 2
     [Teardown]      CloseAllBrowsers
 
 No browser open message
-    [Timeout]    60 seconds
     ${previous}=    SetConfig               LogScreenshot    False
     CloseAllBrowsers
     Run Keyword and Expect Error    QWebDriverError: No browser open*    GoTo    https://www.qentinel.com
@@ -74,7 +73,6 @@ Open Browser with Options and Environment Chromeargs
 
 Open Browser with experimental args
     [tags]          exp             PROBLEM_IN_SAFARI
-    [Timeout]    60 seconds
     Close All Browsers
     OpenBrowser     about:blank     ${BROWSER}
     ...     prefs="download.prompt_for_download": "False", "plugins.always_open_pdf_externally": "True"

--- a/test/acceptance/browser.robot
+++ b/test/acceptance/browser.robot
@@ -3,7 +3,7 @@ Documentation     Tests for opening browsers
 Library           OperatingSystem
 Library           QWeb
 Test Setup        Open Browser And Wait A Bit
-Test Timeout      1min
+Test Timeout      30 seconds
 Suite Teardown    Close All Browsers
 
 *** Variables ***
@@ -25,6 +25,7 @@ Close All Browsers 2
     [Teardown]      CloseAllBrowsers
 
 No browser open message
+    [Timeout]    60 seconds
     ${previous}=    SetConfig               LogScreenshot    False
     CloseAllBrowsers
     Run Keyword and Expect Error    QWebDriverError: No browser open*    GoTo    https://www.qentinel.com
@@ -73,6 +74,7 @@ Open Browser with Options and Environment Chromeargs
 
 Open Browser with experimental args
     [tags]          exp             PROBLEM_IN_SAFARI
+    [Timeout]    60 seconds
     Close All Browsers
     OpenBrowser     about:blank     ${BROWSER}
     ...     prefs="download.prompt_for_download": "False", "plugins.always_open_pdf_externally": "True"

--- a/test/acceptance/browser.robot
+++ b/test/acceptance/browser.robot
@@ -3,7 +3,7 @@ Documentation     Tests for opening browsers
 Library           OperatingSystem
 Library           QWeb
 Test Setup        Open Browser And Wait A Bit
-Test Timeout      60 seconds
+Test Timeout      90 seconds
 Suite Teardown    Close All Browsers
 
 *** Variables ***

--- a/test/acceptance/checkbox.robot
+++ b/test/acceptance/checkbox.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Library           Dialogs
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/checkbox.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/checkbox.robot
+++ b/test/acceptance/checkbox.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Library           Dialogs
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/checkbox.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/checkbox.robot
+++ b/test/acceptance/checkbox.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Library           Dialogs
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/checkbox.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/checkbox.robot
+++ b/test/acceptance/checkbox.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Library           Dialogs
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/checkbox.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/cli.robot
+++ b/test/acceptance/cli.robot
@@ -4,7 +4,7 @@ Library                   QWeb
 Library                   Process
 Suite Setup               Get Python executable
 Suite Teardown            Terminate All Processes
-Test Timeout              20 seconds
+Test Timeout              60 seconds
 
 *** Variables ***
 

--- a/test/acceptance/cli.robot
+++ b/test/acceptance/cli.robot
@@ -4,6 +4,7 @@ Library                   QWeb
 Library                   Process
 Suite Setup               Get Python executable
 Suite Teardown            Terminate All Processes
+Test Timeout              20 seconds
 
 *** Variables ***
 

--- a/test/acceptance/config.robot
+++ b/test/acceptance/config.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Config keywords
 Library           QWeb
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/config.robot
+++ b/test/acceptance/config.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Config keywords
 Library           QWeb
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/config.robot
+++ b/test/acceptance/config.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Config keywords
 Library           QWeb
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/config.robot
+++ b/test/acceptance/config.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Config keywords
 Library           QWeb
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/cookies.robot
+++ b/test/acceptance/cookies.robot
@@ -8,7 +8,7 @@ Suite Setup       OpenBrowser    about:blank    ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Setup        Start Flask Server
 Test Teardown     Terminate All Processes
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 Force Tags        FLASK
 
 

--- a/test/acceptance/cookies.robot
+++ b/test/acceptance/cookies.robot
@@ -8,7 +8,7 @@ Suite Setup       OpenBrowser    about:blank    ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Setup        Start Flask Server
 Test Teardown     Terminate All Processes
-Test Timeout      1min
+Test Timeout      30 seconds
 Force Tags        FLASK
 
 

--- a/test/acceptance/download.robot
+++ b/test/acceptance/download.robot
@@ -6,7 +6,7 @@ Library             QWeb
 Suite Setup         Download Suite Setup
 Suite Teardown      Download Suite Teardown
 Test Teardown       Remove Small and Large Files
-Test Timeout        1min
+Test Timeout        60 seconds
 Force Tags          FLASK
 
 *** Variables ***

--- a/test/acceptance/dragdrop.robot
+++ b/test/acceptance/dragdrop.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/drag.html    ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Setup        SetConfig       WindowSize    1920x1080
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 Test Teardown     Refresh Page
 
 *** Variables ***

--- a/test/acceptance/dragdrop.robot
+++ b/test/acceptance/dragdrop.robot
@@ -4,11 +4,15 @@ Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/drag.html    ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Setup        SetConfig       WindowSize    1920x1080
-Test Timeout      1min
+Test Timeout      30 seconds
 Test Teardown     Refresh Page
 
 *** Variables ***
 ${BROWSER}    chrome
+
+${childnodes}    ${EMPTY}
+${childnodes2}    ${EMPTY}
+${text}    ${EMPTY}
 
 *** Test Cases ***
 Drag and Drop all elements to box

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for Dropdown keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/dropdown.html            ${BROWSER}
 Suite Teardown                  CloseBrowser
-Test Timeout                    30 seconds
+Test Timeout                    60 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for Dropdown keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/dropdown.html            ${BROWSER}
 Suite Teardown                  CloseBrowser
-Test Timeout                    10 seconds
+Test Timeout                    20 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for Dropdown keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/dropdown.html            ${BROWSER}
 Suite Teardown                  CloseBrowser
-Test Timeout                    20 seconds
+Test Timeout                    30 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/dropdown.robot
+++ b/test/acceptance/dropdown.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for Dropdown keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/dropdown.html            ${BROWSER}
 Suite Teardown                  CloseBrowser
-Test Timeout                    1min
+Test Timeout                    10 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -3,7 +3,7 @@ Documentation                   Tests from element keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    10 seconds
+Test Timeout                    20 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -166,7 +166,7 @@ VerifyAttributeNotEquals
 
 VerifyAttributeGreater
     [Tags]                      VerifyAttribute
-    [Timeout]                   20 seconds
+    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     # greater, should pass
     VerifyAttribute             Button3    data-id                          7                   element_type=Text    operator=greater than

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -3,7 +3,7 @@ Documentation                   Tests from element keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    30 seconds
+Test Timeout                    60 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -3,7 +3,7 @@ Documentation                   Tests from element keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    1min
+Test Timeout                    10 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -73,6 +73,7 @@ IsElementFound 4
     Should Be Equal             ${found}                    ${TRUE}
 
 IsElementFoundDelay
+    [Timeout]    30 seconds
     VerifyNoElement             //*[@id\="hide"]
     ClickText                   Show hidden
     ${found}=                   IsElement                   //*[@id\="hide"]            20s
@@ -165,6 +166,7 @@ VerifyAttributeNotEquals
 
 VerifyAttributeGreater
     [Tags]                      VerifyAttribute
+    [Timeout]                   20 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     # greater, should pass
     VerifyAttribute             Button3    data-id                          7                   element_type=Text    operator=greater than
@@ -185,6 +187,7 @@ VerifyAttributeGreaterOrEqual
 
 VerifyAttributeLessThan
     [Tags]                      VerifyAttribute
+    [Timeout]                   20 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     # lower, should pass
     VerifyAttribute             input[value\="Button3"]     data-id                     12347                   element_type=css        operator=less than
@@ -233,6 +236,7 @@ VerifyAttributeIncorrectOperator
 
 VerifyAttributeCheckbox
     [Tags]                      VerifyAttribute
+    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/checkbox.html
     ClickText                   Blue
     VerifyAttribute             //*[@id\="ch_1_1"]          checked                     true
@@ -241,6 +245,7 @@ VerifyAttributeCheckbox
 
 VerifyAttributeNOK
     [Tags]                      VerifyAttribute
+    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     Run Keyword And Expect Error      QWebElementNotFoundError:*    VerifyAttribute      //button[@name\="somethingthatdoesnotexist"]    id    something    timeout=2
     Run Keyword And Expect Error      QWebValueError:*              VerifyAttribute      //button             value                Button2              element_type=Text    timeout=2

--- a/test/acceptance/element.robot
+++ b/test/acceptance/element.robot
@@ -3,7 +3,7 @@ Documentation                   Tests from element keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    20 seconds
+Test Timeout                    30 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -73,7 +73,6 @@ IsElementFound 4
     Should Be Equal             ${found}                    ${TRUE}
 
 IsElementFoundDelay
-    [Timeout]    30 seconds
     VerifyNoElement             //*[@id\="hide"]
     ClickText                   Show hidden
     ${found}=                   IsElement                   //*[@id\="hide"]            20s
@@ -166,7 +165,6 @@ VerifyAttributeNotEquals
 
 VerifyAttributeGreater
     [Tags]                      VerifyAttribute
-    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     # greater, should pass
     VerifyAttribute             Button3    data-id                          7                   element_type=Text    operator=greater than
@@ -187,7 +185,6 @@ VerifyAttributeGreaterOrEqual
 
 VerifyAttributeLessThan
     [Tags]                      VerifyAttribute
-    [Timeout]                   20 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     # lower, should pass
     VerifyAttribute             input[value\="Button3"]     data-id                     12347                   element_type=css        operator=less than
@@ -236,7 +233,6 @@ VerifyAttributeIncorrectOperator
 
 VerifyAttributeCheckbox
     [Tags]                      VerifyAttribute
-    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/checkbox.html
     ClickText                   Blue
     VerifyAttribute             //*[@id\="ch_1_1"]          checked                     true
@@ -245,7 +241,6 @@ VerifyAttributeCheckbox
 
 VerifyAttributeNOK
     [Tags]                      VerifyAttribute
-    [Timeout]                   30 seconds
     Go To                       file://${CURDIR}/../resources/text.html
     Run Keyword And Expect Error      QWebElementNotFoundError:*    VerifyAttribute      //button[@name\="somethingthatdoesnotexist"]    id    something    timeout=2
     Run Keyword And Expect Error      QWebValueError:*              VerifyAttribute      //button             value                Button2              element_type=Text    timeout=2

--- a/test/acceptance/element_corners.robot
+++ b/test/acceptance/element_corners.robot
@@ -3,7 +3,7 @@ Documentation     Tests for corner
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/corners.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/element_corners.robot
+++ b/test/acceptance/element_corners.robot
@@ -3,7 +3,7 @@ Documentation     Tests for corner
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/corners.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/element_corners.robot
+++ b/test/acceptance/element_corners.robot
@@ -3,7 +3,7 @@ Documentation     Tests for corner
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/corners.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/element_corners.robot
+++ b/test/acceptance/element_corners.robot
@@ -3,7 +3,7 @@ Documentation     Tests for corner
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/corners.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/file.robot
+++ b/test/acceptance/file.robot
@@ -3,7 +3,7 @@ Documentation       Test for pdf keywords. Browser needs to be open for Linux pi
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}  --headless
 Suite Teardown      CloseBrowser
-Test Timeout        10 seconds
+Test Timeout        20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/file.robot
+++ b/test/acceptance/file.robot
@@ -3,7 +3,7 @@ Documentation       Test for pdf keywords. Browser needs to be open for Linux pi
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}  --headless
 Suite Teardown      CloseBrowser
-Test Timeout        20 seconds
+Test Timeout        30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/file.robot
+++ b/test/acceptance/file.robot
@@ -3,7 +3,7 @@ Documentation       Test for pdf keywords. Browser needs to be open for Linux pi
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}  --headless
 Suite Teardown      CloseBrowser
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/file.robot
+++ b/test/acceptance/file.robot
@@ -3,7 +3,7 @@ Documentation       Test for pdf keywords. Browser needs to be open for Linux pi
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}  --headless
 Suite Teardown      CloseBrowser
-Test Timeout        1min
+Test Timeout        10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/firefox.robot
+++ b/test/acceptance/firefox.robot
@@ -3,7 +3,7 @@ Documentation     Tests for frame keywords
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/frame.html    ${BROWSER}   -headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    firefox
@@ -40,7 +40,7 @@ Automatic frame search input elements
 
 Automatic frame search table elements
     [Tags]                  jailed
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     UseTable                Sample
     TypeText                r4c1                    Qentiro
     TypeText                r4c2                    Robot
@@ -56,7 +56,7 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                  jailed
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     SetConfig               CSSSelectors            off
     VerifyCheckboxStatus    I have a bike           enabled
     VerifyCheckboxStatus    I should be disabled    disabled

--- a/test/acceptance/firefox.robot
+++ b/test/acceptance/firefox.robot
@@ -3,7 +3,7 @@ Documentation     Tests for frame keywords
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/frame.html    ${BROWSER}   -headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    firefox
@@ -40,6 +40,7 @@ Automatic frame search input elements
 
 Automatic frame search table elements
     [Tags]                  jailed
+    [Timeout]               20 seconds
     UseTable                Sample
     TypeText                r4c1                    Qentiro
     TypeText                r4c2                    Robot
@@ -55,6 +56,7 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                  jailed
+    [Timeout]               20 seconds
     SetConfig               CSSSelectors            off
     VerifyCheckboxStatus    I have a bike           enabled
     VerifyCheckboxStatus    I should be disabled    disabled

--- a/test/acceptance/firefox.robot
+++ b/test/acceptance/firefox.robot
@@ -3,7 +3,7 @@ Documentation     Tests for frame keywords
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/frame.html    ${BROWSER}   -headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    firefox

--- a/test/acceptance/firefox.robot
+++ b/test/acceptance/firefox.robot
@@ -3,7 +3,7 @@ Documentation     Tests for frame keywords
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/frame.html    ${BROWSER}   -headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    firefox
@@ -40,7 +40,6 @@ Automatic frame search input elements
 
 Automatic frame search table elements
     [Tags]                  jailed
-    [Timeout]               30 seconds
     UseTable                Sample
     TypeText                r4c1                    Qentiro
     TypeText                r4c2                    Robot
@@ -56,7 +55,6 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                  jailed
-    [Timeout]               30 seconds
     SetConfig               CSSSelectors            off
     VerifyCheckboxStatus    I have a bike           enabled
     VerifyCheckboxStatus    I should be disabled    disabled

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for frame keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    10 seconds
+Test Timeout                    20 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for frame keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    30 seconds
+Test Timeout                    60 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -3,7 +3,7 @@ Documentation                   Tests for frame keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    20 seconds
+Test Timeout                    30 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -52,7 +52,6 @@ Automatic frame search text elements
 
 Automatic frame search input elements
     [tags]                      inputs
-    [Timeout]                   20 seconds
     TypeText                    First input                 Robot
     TypeText                    Second input                QENROB
     TypeText                    Cell 1 input                20022019
@@ -68,7 +67,6 @@ Automatic frame search input elements
 
 Automatic frame search table elements
     [Tags]                      Frame
-    [Timeout]                   30 seconds
     UseTable                    Sample
     TypeText                    r4c1                        Qentiro
     TypeText                    r4c2                        Robot

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -3,10 +3,11 @@ Documentation                   Tests for frame keywords
 Library                         QWeb
 Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
-Test Timeout                    1min
+Test Timeout                    10 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
+${value}                        ${EMPTY}
 
 *** Test Cases ***
 Refresh Page
@@ -50,7 +51,8 @@ Automatic frame search text elements
     ScrollText                  Input fields with
 
 Automatic frame search input elements
-    [tags]                      inputs                      
+    [tags]                      inputs
+    [Timeout]                   20 seconds
     TypeText                    First input                 Robot
     TypeText                    Second input                QENROB
     TypeText                    Cell 1 input                20022019
@@ -66,6 +68,7 @@ Automatic frame search input elements
 
 Automatic frame search table elements
     [Tags]                      Frame
+    [Timeout]                   30 seconds
     UseTable                    Sample
     TypeText                    r4c1                        Qentiro
     TypeText                    r4c2                        Robot

--- a/test/acceptance/icon.robot
+++ b/test/acceptance/icon.robot
@@ -5,7 +5,7 @@ Suite Setup         OpenBrowser    about:blank    ${BROWSER}
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
 Library             Dialogs
-Test Timeout        1min
+Test Timeout        30 seconds
 
 *** Variables ***
 ${BROWSER}                  chrome

--- a/test/acceptance/icon.robot
+++ b/test/acceptance/icon.robot
@@ -5,7 +5,7 @@ Suite Setup         OpenBrowser    about:blank    ${BROWSER}
 Test Setup          GoTo    file://${CURDIR}/../resources/items.html
 Suite Teardown      CloseBrowser
 Library             Dialogs
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}                  chrome

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     10 seconds
+Test Timeout     20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     20 seconds
+Test Timeout     30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     1min
+Test Timeout     10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/input.robot
+++ b/test/acceptance/input.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     30 seconds
+Test Timeout     60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/javascript.robot
+++ b/test/acceptance/javascript.robot
@@ -3,7 +3,7 @@ Documentation     Tests for Javascript keyword
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/javascript.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/javascript.robot
+++ b/test/acceptance/javascript.robot
@@ -3,10 +3,11 @@ Documentation     Tests for Javascript keyword
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/javascript.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
+${TITLE}      ${EMPTY}
 
 *** Test Cases ***
 Execute Javascript

--- a/test/acceptance/javascript.robot
+++ b/test/acceptance/javascript.robot
@@ -3,7 +3,7 @@ Documentation     Tests for Javascript keyword
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/javascript.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/javascript.robot
+++ b/test/acceptance/javascript.robot
@@ -3,7 +3,7 @@ Documentation     Tests for Javascript keyword
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/javascript.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/lists.robot
+++ b/test/acceptance/lists.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          Collections
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/lists.html  ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     10 seconds
+Test Timeout     20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -43,7 +43,7 @@ GetList substring
     ShouldBeEqual           ${text}         entine
 
 UseList and get errors
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     UseList                 Robot testing
     ${err}                          Set Variable    QWebValueMismatchError: Expected length*
     Run Keyword and Expect Error   ${err}    VerifyLength       6

--- a/test/acceptance/lists.robot
+++ b/test/acceptance/lists.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          Collections
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/lists.html  ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     20 seconds
+Test Timeout     30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -43,7 +43,6 @@ GetList substring
     ShouldBeEqual           ${text}         entine
 
 UseList and get errors
-    [Timeout]               30 seconds
     UseList                 Robot testing
     ${err}                          Set Variable    QWebValueMismatchError: Expected length*
     Run Keyword and Expect Error   ${err}    VerifyLength       6

--- a/test/acceptance/lists.robot
+++ b/test/acceptance/lists.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          Collections
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/lists.html  ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     30 seconds
+Test Timeout     60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -89,7 +89,6 @@ Uselist xpath and parent
     VerifyList              Box 2           2
 
 Uselist with child and expect error
-    [Timeout]               60 seconds
     ${err}                          Set Variable    QWebElementNotFoundError: Unable*
     Run Keyword And Expect Error   ${err}    UseList    innerBox1    selector=class    child=.boxes
     Run Keyword And Expect Error   ${err}    UseList    Robot Testing    child=ol

--- a/test/acceptance/lists.robot
+++ b/test/acceptance/lists.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          Collections
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/lists.html  ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     1min
+Test Timeout     10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -43,6 +43,7 @@ GetList substring
     ShouldBeEqual           ${text}         entine
 
 UseList and get errors
+    [Timeout]               20 seconds
     UseList                 Robot testing
     ${err}                          Set Variable    QWebValueMismatchError: Expected length*
     Run Keyword and Expect Error   ${err}    VerifyLength       6
@@ -89,6 +90,7 @@ Uselist xpath and parent
     VerifyList              Box 2           2
 
 Uselist with child and expect error
+    [Timeout]               60 seconds
     ${err}                          Set Variable    QWebElementNotFoundError: Unable*
     Run Keyword And Expect Error   ${err}    UseList    innerBox1    selector=class    child=.boxes
     Run Keyword And Expect Error   ${err}    UseList    Robot Testing    child=ol

--- a/test/acceptance/no_body.robot
+++ b/test/acceptance/no_body.robot
@@ -3,7 +3,7 @@ Documentation     Test for selecting active xpath
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/no_body.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/no_body.robot
+++ b/test/acceptance/no_body.robot
@@ -3,7 +3,7 @@ Documentation     Test for selecting active xpath
 Library           QWeb
 Suite Setup       OpenBrowser    file://${CURDIR}/../resources/no_body.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/paceblock.robot
+++ b/test/acceptance/paceblock.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     10 seconds
+Test Timeout     20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/paceblock.robot
+++ b/test/acceptance/paceblock.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     20 seconds
+Test Timeout     30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/paceblock.robot
+++ b/test/acceptance/paceblock.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     1min
+Test Timeout     10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/paceblock.robot
+++ b/test/acceptance/paceblock.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Library          OperatingSystem
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
-Test Timeout     30 seconds
+Test Timeout     60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/requests.robot
+++ b/test/acceptance/requests.robot
@@ -8,7 +8,7 @@ Suite Setup       OpenBrowser    about:blank    ${BROWSER}
 Test Setup        Start Flask Server
 Test Teardown     Terminate All Processes
 Suite Teardown    CloseAllBrowsers
-Test Timeout      1min
+Test Timeout      30 seconds
 Force Tags        FLASK
 
 *** Variables ***

--- a/test/acceptance/requests.robot
+++ b/test/acceptance/requests.robot
@@ -8,7 +8,7 @@ Suite Setup       OpenBrowser    about:blank    ${BROWSER}
 Test Setup        Start Flask Server
 Test Teardown     Terminate All Processes
 Suite Teardown    CloseAllBrowsers
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 Force Tags        FLASK
 
 *** Variables ***

--- a/test/acceptance/screenshot.robot
+++ b/test/acceptance/screenshot.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Library             OperatingSystem
 Suite Setup         OpenBrowser    file://${CURDIR}/../resources/text.html    ${BROWSER}  #--headless
 Suite Teardown      CloseBrowser
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${SCREENSHOT_NAME}    test_screen_shot.png

--- a/test/acceptance/screenshot.robot
+++ b/test/acceptance/screenshot.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Library             OperatingSystem
 Suite Setup         OpenBrowser    file://${CURDIR}/../resources/text.html    ${BROWSER}  #--headless
 Suite Teardown      CloseBrowser
-Test Timeout        20 seconds
+Test Timeout        30 seconds
 
 *** Variables ***
 ${SCREENSHOT_NAME}    test_screen_shot.png

--- a/test/acceptance/screenshot.robot
+++ b/test/acceptance/screenshot.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Library             OperatingSystem
 Suite Setup         OpenBrowser    file://${CURDIR}/../resources/text.html    ${BROWSER}  #--headless
 Suite Teardown      CloseBrowser
-Test Timeout        1min
+Test Timeout        20 seconds
 
 *** Variables ***
 ${SCREENSHOT_NAME}    test_screen_shot.png
@@ -13,11 +13,13 @@ ${BROWSER}    chrome
 *** Keywords ***
 Remove Test Screenshot
     [Arguments]     ${file_name}
+    [Timeout]       10 seconds
     Remove File     ${OUTPUT_DIR}${/}screenshots${/}${file_name}
 
 *** Test Cases ***
 LogPage does not give errors
     [Tags]         LogPage
+    [Timeout]      10 seconds
     LogPage
 
 Screenshot Functionality Works

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -3,7 +3,7 @@ Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -3,7 +3,7 @@ Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -3,7 +3,7 @@ Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -23,6 +23,7 @@ InputElements
     VerifyInputValue        field3          FooBar
 
 CheckboxElements
+    [Timeout]               30 seconds
     ClickCheckbox           I have a                on
     VerifyCheckboxValue     I have a bike           on
     ClickCheckbox           Sample text             on

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -3,7 +3,7 @@ Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -23,7 +23,6 @@ InputElements
     VerifyInputValue        field3          FooBar
 
 CheckboxElements
-    [Timeout]               30 seconds
     ClickCheckbox           I have a                on
     VerifyCheckboxValue     I have a bike           on
     ClickCheckbox           Sample text             on

--- a/test/acceptance/selectors.robot
+++ b/test/acceptance/selectors.robot
@@ -3,7 +3,7 @@ Documentation     Tests for selector attribute
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/selectors.robot
+++ b/test/acceptance/selectors.robot
@@ -3,7 +3,7 @@ Documentation     Tests for selector attribute
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/selectors.robot
+++ b/test/acceptance/selectors.robot
@@ -3,7 +3,7 @@ Documentation     Tests for selector attribute
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/self_repairing_input.robot
+++ b/test/acceptance/self_repairing_input.robot
@@ -6,7 +6,7 @@ Suite Setup  Run Keyword If    '${BROWSER}'=='chrome'
 ...  ELSE  OpenBrowser  file://${CURDIR}/../resources/self_repairing_example.html  ${BROWSER}
 ...  --headless
 Suite Teardown  CloseBrowser
-Test Timeout        10 seconds
+Test Timeout        20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -18,7 +18,7 @@ TypeText To Selfrepairing Input Works
     VerifyInputValue    xpath\=//input[@id\="fname"]   FOOOO
 
 TypeText checkinput value one time check True
-    [Timeout]      20 seconds
+    [Timeout]      30 seconds
     SetConfig      LineBreak       \ue000
     ${message}=    Set Variable    QWebValueError: Expected value*
     Run Keyword And Expect Error    ${message}

--- a/test/acceptance/self_repairing_input.robot
+++ b/test/acceptance/self_repairing_input.robot
@@ -6,7 +6,7 @@ Suite Setup  Run Keyword If    '${BROWSER}'=='chrome'
 ...  ELSE  OpenBrowser  file://${CURDIR}/../resources/self_repairing_example.html  ${BROWSER}
 ...  --headless
 Suite Teardown  CloseBrowser
-Test Timeout        1min
+Test Timeout        10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -18,6 +18,7 @@ TypeText To Selfrepairing Input Works
     VerifyInputValue    xpath\=//input[@id\="fname"]   FOOOO
 
 TypeText checkinput value one time check True
+    [Timeout]      20 seconds
     SetConfig      LineBreak       \ue000
     ${message}=    Set Variable    QWebValueError: Expected value*
     Run Keyword And Expect Error    ${message}

--- a/test/acceptance/self_repairing_input.robot
+++ b/test/acceptance/self_repairing_input.robot
@@ -6,7 +6,7 @@ Suite Setup  Run Keyword If    '${BROWSER}'=='chrome'
 ...  ELSE  OpenBrowser  file://${CURDIR}/../resources/self_repairing_example.html  ${BROWSER}
 ...  --headless
 Suite Teardown  CloseBrowser
-Test Timeout        20 seconds
+Test Timeout        30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -18,7 +18,6 @@ TypeText To Selfrepairing Input Works
     VerifyInputValue    xpath\=//input[@id\="fname"]   FOOOO
 
 TypeText checkinput value one time check True
-    [Timeout]      30 seconds
     SetConfig      LineBreak       \ue000
     ${message}=    Set Variable    QWebValueError: Expected value*
     Run Keyword And Expect Error    ${message}

--- a/test/acceptance/self_repairing_input.robot
+++ b/test/acceptance/self_repairing_input.robot
@@ -6,7 +6,7 @@ Suite Setup  Run Keyword If    '${BROWSER}'=='chrome'
 ...  ELSE  OpenBrowser  file://${CURDIR}/../resources/self_repairing_example.html  ${BROWSER}
 ...  --headless
 Suite Teardown  CloseBrowser
-Test Timeout        30 seconds
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/shadow_dom.robot
+++ b/test/acceptance/shadow_dom.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser              file://${CURDIR}/../resources/shadow_dom.html  ${BROWSER}
 Suite Teardown    Shadow Teardown
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -11,7 +11,6 @@ ${BROWSER}         chrome
 *** Test Cases ***
 Basic inteactions with Shadow DOM
     [Setup]                SetConfig              ShadowDOM                     False
-    [Timeout]              60 seconds
  
     ${error}=               Run Keyword and Expect Error       *
     ...                    VerifyText      Local Target in Shadow DOM     partial_match=False  timeout=2
@@ -102,7 +101,6 @@ Text Counts with shadow DOM
 External site with shadow DOM
     [tags]                  shadow_dom
     [Setup]                 SetConfig              ShadowDOM                     False
-    [Timeout]               60 seconds
     GoTo                    https://developer.servicenow.com/dev.do
     # dismiss cookie dialog
     ${cookie_dialog}=       IsText      Required Only    timeout=5

--- a/test/acceptance/shadow_dom.robot
+++ b/test/acceptance/shadow_dom.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser              file://${CURDIR}/../resources/shadow_dom.html  ${BROWSER}
 Suite Teardown    Shadow Teardown
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -66,7 +66,6 @@ VerifyAll & VerifyAny with shadow DOM
 
 Input keywords with shadow DOM
     [Setup]                SetConfig              ShadowDOM                     False
-    [Timeout]              30 seconds
     GoTo                   file://${CURDIR}/../resources/shadow_dom.html
     # verify inputs using normal dom only
     TypeText               username                      John Doe               # in normal/light dom

--- a/test/acceptance/shadow_dom.robot
+++ b/test/acceptance/shadow_dom.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser              file://${CURDIR}/../resources/shadow_dom.html  ${BROWSER}
 Suite Teardown    Shadow Teardown
-Test Timeout      1min
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -11,6 +11,7 @@ ${BROWSER}         chrome
 *** Test Cases ***
 Basic inteactions with Shadow DOM
     [Setup]                SetConfig              ShadowDOM                     False
+    [Timeout]              60 seconds
  
     ${error}=               Run Keyword and Expect Error       *
     ...                    VerifyText      Local Target in Shadow DOM     partial_match=False  timeout=2
@@ -65,6 +66,7 @@ VerifyAll & VerifyAny with shadow DOM
 
 Input keywords with shadow DOM
     [Setup]                SetConfig              ShadowDOM                     False
+    [Timeout]              30 seconds
     GoTo                   file://${CURDIR}/../resources/shadow_dom.html
     # verify inputs using normal dom only
     TypeText               username                      John Doe               # in normal/light dom
@@ -101,6 +103,7 @@ Text Counts with shadow DOM
 External site with shadow DOM
     [tags]                  shadow_dom
     [Setup]                 SetConfig              ShadowDOM                     False
+    [Timeout]               60 seconds
     GoTo                    https://developer.servicenow.com/dev.do
     # dismiss cookie dialog
     ${cookie_dialog}=       IsText      Required Only    timeout=5

--- a/test/acceptance/swipe.robot
+++ b/test/acceptance/swipe.robot
@@ -4,7 +4,7 @@ Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}
 Test Setup          GoTo    file://${CURDIR}/../resources/swipe.html
 Suite Teardown      CloseBrowser
-Test Timeout        1min
+Test Timeout        60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -41,6 +41,7 @@ Swipe with starting points and verify images
 
 ScrollTo
     [Tags]            ScrollTo  RESOLUTION_DEPENDENCY
+    [Timeout]         10 seconds
     SetConfig         WindowSize   1600x900
     GoTo              file://${CURDIR}/../resources/text.html
     ScrollTo          Current scroll

--- a/test/acceptance/swipe.robot
+++ b/test/acceptance/swipe.robot
@@ -41,7 +41,7 @@ Swipe with starting points and verify images
 
 ScrollTo
     [Tags]            ScrollTo  RESOLUTION_DEPENDENCY
-    [Timeout]         10 seconds
+    [Timeout]         20 seconds
     SetConfig         WindowSize   1600x900
     GoTo              file://${CURDIR}/../resources/text.html
     ScrollTo          Current scroll

--- a/test/acceptance/table.robot
+++ b/test/acceptance/table.robot
@@ -3,7 +3,7 @@ Documentation    Tests for table keywords
 Library          QWeb
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/table.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
-Test Timeout     10 seconds
+Test Timeout     20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/table.robot
+++ b/test/acceptance/table.robot
@@ -3,7 +3,7 @@ Documentation    Tests for table keywords
 Library          QWeb
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/table.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
-Test Timeout     30 seconds
+Test Timeout     60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/table.robot
+++ b/test/acceptance/table.robot
@@ -3,7 +3,7 @@ Documentation    Tests for table keywords
 Library          QWeb
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/table.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
-Test Timeout     20 seconds
+Test Timeout     30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -27,7 +27,6 @@ Verify Value Negative Cases
     Run Keyword And Expect Error       QWebValueError*   VerifyTable   r2c1       Foo  timeout=1
 
 Type text to table and verify values
-    [Timeout]               30 seconds
     UseTable                Sample
     TypeText                r4c1                    Qentiro
     TypeText                r4c2                    Robot
@@ -41,7 +40,6 @@ Type text to table and verify values
     ...   VerifyInputValue              r4c4        2019-02-23          timeout=1
 
 Get Cell Value to variable
-    [Timeout]               30 seconds 
     UseTable                Sample
     ${TEST}                 GetCellText             r2c3
     ShouldBeEqual           ${TEST}                 ${EMPTY}

--- a/test/acceptance/table.robot
+++ b/test/acceptance/table.robot
@@ -3,7 +3,7 @@ Documentation    Tests for table keywords
 Library          QWeb
 Suite Setup      OpenBrowser    file://${CURDIR}/../resources/table.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
-Test Timeout     1min
+Test Timeout     10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -27,6 +27,7 @@ Verify Value Negative Cases
     Run Keyword And Expect Error       QWebValueError*   VerifyTable   r2c1       Foo  timeout=1
 
 Type text to table and verify values
+    [Timeout]               30 seconds
     UseTable                Sample
     TypeText                r4c1                    Qentiro
     TypeText                r4c2                    Robot
@@ -40,7 +41,7 @@ Type text to table and verify values
     ...   VerifyInputValue              r4c4        2019-02-23          timeout=1
 
 Get Cell Value to variable
-    [Tags]
+    [Timeout]               30 seconds 
     UseTable                Sample
     ${TEST}                 GetCellText             r2c3
     ShouldBeEqual           ${TEST}                 ${EMPTY}

--- a/test/acceptance/table2.robot
+++ b/test/acceptance/table2.robot
@@ -3,7 +3,7 @@ Documentation     More tests for table keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/table2.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -178,7 +178,6 @@ Anchors and indexes
     VerifyCheckBoxValue     r-1c6                   On                      index=2
 
 Using Cells, starts from last one
-    [Timeout]               30 seconds
     UseTable                Some Text
     ClickCheckbox           r-1c-1                  On
     ClickCheckbox           r-1c-1                  Off                     index=2
@@ -234,7 +233,6 @@ Use child table
 
 Get first empty row
     [tags]                  empty
-    [Timeout]               30 seconds
     UseTable                Stars
     TypeText                r?EMPTY/c?First         Qentsu
     TypeText                r?EMPTY/c?Last          Robot

--- a/test/acceptance/table2.robot
+++ b/test/acceptance/table2.robot
@@ -3,7 +3,7 @@ Documentation     More tests for table keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/table2.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
@@ -123,7 +123,6 @@ Use general kws with Table Get row by text or start counting from last cell
     ClickCell               r-1c6
 
 Anchors and indexes
-    [Timeout]               60 seconds
     HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Text Node
     #Using index anchor(2)

--- a/test/acceptance/table2.robot
+++ b/test/acceptance/table2.robot
@@ -3,7 +3,7 @@ Documentation     More tests for table keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/table2.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/table2.robot
+++ b/test/acceptance/table2.robot
@@ -3,10 +3,11 @@ Documentation     More tests for table keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/table2.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
+${value}      ${EMPTY}
 
 *** Test Cases ***
 Use table kw:s with text locator
@@ -122,7 +123,7 @@ Use general kws with Table Get row by text or start counting from last cell
     ClickCell               r-1c6
 
 Anchors and indexes
-    [Tags]
+    [Timeout]               60 seconds
     HoverText               Text Node              # make bottom elements visible - Safari
     UseTable                Text Node
     #Using index anchor(2)
@@ -177,7 +178,7 @@ Anchors and indexes
     VerifyCheckBoxValue     r-1c6                   On                      index=2
 
 Using Cells, starts from last one
-    [Tags]
+    [Timeout]               30 seconds
     UseTable                Some Text
     ClickCheckbox           r-1c-1                  On
     ClickCheckbox           r-1c-1                  Off                     index=2
@@ -233,6 +234,7 @@ Use child table
 
 Get first empty row
     [tags]                  empty
+    [Timeout]               30 seconds
     UseTable                Stars
     TypeText                r?EMPTY/c?First         Qentsu
     TypeText                r?EMPTY/c?Last          Robot

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/text.html  ${BROWSER}   --HEADLESS
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -102,7 +102,6 @@ VerifyTextCountFail
 
 VerifyTextCountDelay
     [Tags]                  VerifyTextCount
-    [Timeout]               30 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyTextCount         Counttextyjku    3
     ClickText               Counttextyjku    anchorcount
@@ -239,7 +238,6 @@ IsText Xpath False
 
 IsText Timeout
     [Tags]                  IsText
-    [Timeout]               30 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden
@@ -318,7 +316,6 @@ ClickText Overlapping
     Run Keyword and Expect Error   ${message}    ClickText     Button6    1    0.1s
 
 Click Button and verify hidden text
-    [Timeout]               30 seconds
     RefreshPage
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden
@@ -412,19 +409,16 @@ SkimClick slowly disabling button
 
 SkimClickCorrectErr
     [tags]                  
-    [Timeout]               30 seconds
     ${message}=    Set Variable    QWebValueError: Page contained the text "Click me" after timeout*
     Run Keyword and Expect Error   ${message}   SkimClick   HoverDropdown   Click me    timeout=2
 
 ScanClickCorrectErr2
     [tags]                  err
-    [Timeout]               30 seconds
     RefreshPage
     ${message}=    Set Variable    QWebElementNotFoundError: Unable to find element for locator skim/scan clicked!*
     Run Keyword and Expect Error   ${message}   ScanClick   HoverDropdown   skim/scan clicked!   timeout=2
 
 ScanClick with disabling button
-    [Timeout]               30 seconds
     RefreshPage
     ScanClick               SkimClick disable button    skim/scan clicked!   interval=1
 
@@ -447,7 +441,6 @@ Click while xpath
 
 Click Until
     [tags]                   whileuntil
-    [Timeout]                30 seconds
     RefreshPage
     ClickUntil               Clicks: 2      Click me     interval 1s  timeout=15s
 

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/text.html  ${BROWSER}   --HEADLESS
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -102,7 +102,7 @@ VerifyTextCountFail
 
 VerifyTextCountDelay
     [Tags]                  VerifyTextCount
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyTextCount         Counttextyjku    3
     ClickText               Counttextyjku    anchorcount
@@ -239,7 +239,7 @@ IsText Xpath False
 
 IsText Timeout
     [Tags]                  IsText
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden
@@ -318,7 +318,7 @@ ClickText Overlapping
     Run Keyword and Expect Error   ${message}    ClickText     Button6    1    0.1s
 
 Click Button and verify hidden text
-    [Timeout]               20 seconds
+    [Timeout]               30 seconds
     RefreshPage
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -617,6 +617,7 @@ VerifyAny From List All Found
 
 VerifyAny From List With All But One Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
+    [Timeout]    60 seconds
     ${iddqd}=               Create List      exercitation   qui officia     This Should Not Be Found
     VerifyAny            ${iddqd}  
 

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -3,10 +3,12 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/text.html  ${BROWSER}   --HEADLESS
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
+${y_start}         ${EMPTY}
+${y_end}           ${EMPTY}
 
 *** Test Cases ***
 VerifyText needs to be exact match
@@ -100,6 +102,7 @@ VerifyTextCountFail
 
 VerifyTextCountDelay
     [Tags]                  VerifyTextCount
+    [Timeout]               20 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyTextCount         Counttextyjku    3
     ClickText               Counttextyjku    anchorcount
@@ -236,6 +239,7 @@ IsText Xpath False
 
 IsText Timeout
     [Tags]                  IsText
+    [Timeout]               20 seconds
     Go To                   file://${CURDIR}/../resources/text.html
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden
@@ -314,6 +318,7 @@ ClickText Overlapping
     Run Keyword and Expect Error   ${message}    ClickText     Button6    1    0.1s
 
 Click Button and verify hidden text
+    [Timeout]               20 seconds
     RefreshPage
     VerifyNoText            Delayed hidden text
     ClickText               Show hidden
@@ -406,17 +411,20 @@ SkimClick slowly disabling button
     VerifyText              skim/scan clicked!
 
 SkimClickCorrectErr
-    [tags]                  err
+    [tags]                  
+    [Timeout]               30 seconds
     ${message}=    Set Variable    QWebValueError: Page contained the text "Click me" after timeout*
     Run Keyword and Expect Error   ${message}   SkimClick   HoverDropdown   Click me    timeout=2
 
-ScanClickCorrectErr
+ScanClickCorrectErr2
     [tags]                  err
+    [Timeout]               30 seconds
     RefreshPage
     ${message}=    Set Variable    QWebElementNotFoundError: Unable to find element for locator skim/scan clicked!*
     Run Keyword and Expect Error   ${message}   ScanClick   HoverDropdown   skim/scan clicked!   timeout=2
 
 ScanClick with disabling button
+    [Timeout]               30 seconds
     RefreshPage
     ScanClick               SkimClick disable button    skim/scan clicked!   interval=1
 
@@ -439,11 +447,13 @@ Click while xpath
 
 Click Until
     [tags]                   whileuntil
+    [Timeout]                30 seconds
     RefreshPage
     ClickUntil               Clicks: 2      Click me     interval 1s  timeout=15s
 
 Click Until xpath
     [tags]                  whileuntil
+    [Timeout]               60 seconds
     RefreshPage
     ClickUntil               Clicks: 3      //*[text()\="Click me"]   interval=2  timeout=8s
     ClickUntil               xpath\=//*[text()\="7"]      Click me      interval=1
@@ -455,6 +465,7 @@ Click Until wrong pre condition
 
 ClickUntil wait element to appear
     [tags]                  whileuntil
+    [Timeout]               60 seconds
     RefreshPage
     ClickUntil              hidden-treasure     Show hidden     element=True
     ${message}=    Set Variable    QWebValueError: Element to appear is already*
@@ -462,17 +473,20 @@ ClickUntil wait element to appear
 
 ClickWhile wait element to disappear
     [tags]                  whileuntil
+    [Timeout]               60 seconds
     ClickWhile              hidden-treasure    Hide Text     element=True
     ${message}=    Set Variable    QWebValueError: Element to disappear is not visible*
     Run Keyword and Expect Error   ${message}   ClickWhile   hidden-treasure    Hide Text   element=True
 
 ClickItemWhile
+    [Timeout]               60 seconds
     RefreshPage
     ClickItemWhile          Clicks: 0          screen
     ${message}=             Set Variable       QWebValueError: Text to disappear is not visible*
     Run Keyword and Expect Error   ${message}  ClickItemWhile          Clicks: 0          screen
 
 ClickItemUntil
+    [Timeout]               60 seconds
     ClickItemUntil          Clicks: 4          screen      interval=2
     ${message}=             Set Variable       QWebValueError: Text to appear*
     Run Keyword and Expect Error   ${message}  ClickItemUntil   Clicks: 4    screen  timeout=2

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -3,7 +3,7 @@ Documentation     Tests for text keywords
 Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/text.html  ${BROWSER}   --HEADLESS
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}         chrome
@@ -446,7 +446,6 @@ Click Until
 
 Click Until xpath
     [tags]                  whileuntil
-    [Timeout]               60 seconds
     RefreshPage
     ClickUntil               Clicks: 3      //*[text()\="Click me"]   interval=2  timeout=8s
     ClickUntil               xpath\=//*[text()\="7"]      Click me      interval=1
@@ -458,7 +457,6 @@ Click Until wrong pre condition
 
 ClickUntil wait element to appear
     [tags]                  whileuntil
-    [Timeout]               60 seconds
     RefreshPage
     ClickUntil              hidden-treasure     Show hidden     element=True
     ${message}=    Set Variable    QWebValueError: Element to appear is already*
@@ -466,20 +464,17 @@ ClickUntil wait element to appear
 
 ClickWhile wait element to disappear
     [tags]                  whileuntil
-    [Timeout]               60 seconds
     ClickWhile              hidden-treasure    Hide Text     element=True
     ${message}=    Set Variable    QWebValueError: Element to disappear is not visible*
     Run Keyword and Expect Error   ${message}   ClickWhile   hidden-treasure    Hide Text   element=True
 
 ClickItemWhile
-    [Timeout]               60 seconds
     RefreshPage
     ClickItemWhile          Clicks: 0          screen
     ${message}=             Set Variable       QWebValueError: Text to disappear is not visible*
     Run Keyword and Expect Error   ${message}  ClickItemWhile          Clicks: 0          screen
 
 ClickItemUntil
-    [Timeout]               60 seconds
     ClickItemUntil          Clicks: 4          screen      interval=2
     ${message}=             Set Variable       QWebValueError: Text to appear*
     Run Keyword and Expect Error   ${message}  ClickItemUntil   Clicks: 4    screen  timeout=2
@@ -606,7 +601,6 @@ VerifyAny From File Content With All But One Found
 
 VerifyAny From File Content With None Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
-    [Timeout]    60 seconds
     Run Keyword and Expect Error   QWebValueError: Could not find any of the texts*    VerifyAny    test7.txt  
      
 VerifyAny From List All Found
@@ -617,13 +611,11 @@ VerifyAny From List All Found
 
 VerifyAny From List With All But One Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
-    [Timeout]    60 seconds
     ${iddqd}=               Create List      exercitation   qui officia     This Should Not Be Found
     VerifyAny            ${iddqd}  
 
 VerifyAny From List With None Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
-    [Timeout]    60 seconds
     ${iddqd}=               Create List      exercixxxtation   qxxui officiaxxx     This Should Not Be Found
     Run Keyword and Expect Error   *   VerifyAny      ${iddqd}   
 

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -606,6 +606,7 @@ VerifyAny From File Content With All But One Found
 
 VerifyAny From File Content With None Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
+    [Timeout]    60 seconds
     Run Keyword and Expect Error   QWebValueError: Could not find any of the texts*    VerifyAny    test7.txt  
      
 VerifyAny From List All Found

--- a/test/acceptance/text.robot
+++ b/test/acceptance/text.robot
@@ -623,6 +623,7 @@ VerifyAny From List With All But One Found
 
 VerifyAny From List With None Found
     [tags]	PROBLEM_IN_FIREFOX      verify_any
+    [Timeout]    60 seconds
     ${iddqd}=               Create List      exercixxxtation   qxxui officiaxxx     This Should Not Be Found
     Run Keyword and Expect Error   *   VerifyAny      ${iddqd}   
 

--- a/test/acceptance/text_multi.robot
+++ b/test/acceptance/text_multi.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/multielement_text.html  ${BROWSER}
 ...              --headless
 Suite Teardown   CloseBrowser
-Test Timeout     30 seconds
+Test Timeout     60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/text_multi.robot
+++ b/test/acceptance/text_multi.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/multielement_text.html  ${BROWSER}
 ...              --headless
 Suite Teardown   CloseBrowser
-Test Timeout     20 seconds
+Test Timeout     30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/text_multi.robot
+++ b/test/acceptance/text_multi.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/multielement_text.html  ${BROWSER}
 ...              --headless
 Suite Teardown   CloseBrowser
-Test Timeout     10 seconds
+Test Timeout     20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/text_multi.robot
+++ b/test/acceptance/text_multi.robot
@@ -4,7 +4,7 @@ Library          QWeb
 Suite Setup      OpenBrowser  file://${CURDIR}/../resources/multielement_text.html  ${BROWSER}
 ...              --headless
 Suite Teardown   CloseBrowser
-Test Timeout     1min
+Test Timeout     10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/upload.robot
+++ b/test/acceptance/upload.robot
@@ -3,10 +3,11 @@ Documentation     Tests for UploadFile keyword
 Library           QWeb
 Suite Setup       SuiteStart
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
+${value}      ${EMPTY}
 
 *** Test Cases ***
 Upload files with index

--- a/test/acceptance/upload.robot
+++ b/test/acceptance/upload.robot
@@ -3,7 +3,7 @@ Documentation     Tests for UploadFile keyword
 Library           QWeb
 Suite Setup       SuiteStart
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/upload.robot
+++ b/test/acceptance/upload.robot
@@ -3,7 +3,7 @@ Documentation     Tests for UploadFile keyword
 Library           QWeb
 Suite Setup       SuiteStart
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/upload.robot
+++ b/test/acceptance/upload.robot
@@ -3,7 +3,7 @@ Documentation     Tests for UploadFile keyword
 Library           QWeb
 Suite Setup       SuiteStart
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/verifylinks.robot
+++ b/test/acceptance/verifylinks.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/verifylinks.html  ${BROWSER}
 ...               --headless
 Suite Teardown    CloseBrowser
-Test Timeout      10 seconds
+Test Timeout      20 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/verifylinks.robot
+++ b/test/acceptance/verifylinks.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/verifylinks.html  ${BROWSER}
 ...               --headless
 Suite Teardown    CloseBrowser
-Test Timeout      30 seconds
+Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/verifylinks.robot
+++ b/test/acceptance/verifylinks.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/verifylinks.html  ${BROWSER}
 ...               --headless
 Suite Teardown    CloseBrowser
-Test Timeout      1min
+Test Timeout      10 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/verifylinks.robot
+++ b/test/acceptance/verifylinks.robot
@@ -4,7 +4,7 @@ Library           QWeb
 Suite Setup       OpenBrowser  file://${CURDIR}/../resources/verifylinks.html  ${BROWSER}
 ...               --headless
 Suite Teardown    CloseBrowser
-Test Timeout      20 seconds
+Test Timeout      30 seconds
 
 *** Variables ***
 ${BROWSER}    chrome

--- a/test/acceptance/window.robot
+++ b/test/acceptance/window.robot
@@ -4,7 +4,7 @@ Library                         QWeb
 Library                         Collections
 Test Setup                      OpenBrowser                 about:blank                 ${BROWSER}                  --headless
 Test Teardown                   CloseBrowser
-Test Timeout                    60 seconds
+Test Timeout                    90 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome

--- a/test/acceptance/window.robot
+++ b/test/acceptance/window.robot
@@ -4,7 +4,7 @@ Library                         QWeb
 Library                         Collections
 Test Setup                      OpenBrowser                 about:blank                 ${BROWSER}                  --headless
 Test Teardown                   CloseBrowser
-Test Timeout                    1min
+Test Timeout                    20 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -66,6 +66,7 @@ Switch window, check context
 
 Switch window, special parameter NEW
     [Tags]                      Window    SwitchWindow
+    [Timeout]                   60 seconds
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -86,6 +87,7 @@ Switch window, special parameter NEW
 
 Switch window, alphanumeric parameters
     [Tags]                      Window    SwitchWindow
+    [Timeout]                   60 seconds
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -126,6 +128,7 @@ Switch window, no other window
 
 Switch Window, delay
     [Tags]                      Window    SwitchWindow
+    [Timeout]                   60 seconds
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     Execute Javascript          setTimeout('window.open()', 3000);
@@ -176,11 +179,13 @@ Title and url
 
 Set Window Size
     [Documentation]             Only setting the size, not verifying anything.
+    [Timeout]                   60 seconds
     SetConfig                   WindowSize                  1000X800
 
 Maximize Window
     [Documentation]             Tests for MaximizeWindow keyword
     [Tags]                      Window    MaximizeWindow
+    [Timeout]                   60 seconds
     GoTo                        http://howbigismybrowser.com/
     Sleep                       2                           # wait for browser
     SetConfig                   WindowSize                  550X550

--- a/test/acceptance/window.robot
+++ b/test/acceptance/window.robot
@@ -4,7 +4,7 @@ Library                         QWeb
 Library                         Collections
 Test Setup                      OpenBrowser                 about:blank                 ${BROWSER}                  --headless
 Test Teardown                   CloseBrowser
-Test Timeout                    30 seconds
+Test Timeout                    60 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome
@@ -66,7 +66,6 @@ Switch window, check context
 
 Switch window, special parameter NEW
     [Tags]                      Window    SwitchWindow
-    [Timeout]                   60 seconds
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -87,7 +86,6 @@ Switch window, special parameter NEW
 
 Switch window, alphanumeric parameters
     [Tags]                      Window    SwitchWindow
-    [Timeout]                   60 seconds
     ${driver}=                  Open New Tab Link Page
     Length Should Be            ${driver.window_handles}    2
     VerifyNoText                Liirum laarum               3                           # should not find new window text yet as focus is on parent page
@@ -128,7 +126,6 @@ Switch window, no other window
 
 Switch Window, delay
     [Tags]                      Window    SwitchWindow
-    [Timeout]                   60 seconds
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
     Execute Javascript          setTimeout('window.open()', 3000);
@@ -179,13 +176,11 @@ Title and url
 
 Set Window Size
     [Documentation]             Only setting the size, not verifying anything.
-    [Timeout]                   60 seconds
     SetConfig                   WindowSize                  1000X800
 
 Maximize Window
     [Documentation]             Tests for MaximizeWindow keyword
     [Tags]                      Window    MaximizeWindow
-    [Timeout]                   60 seconds
     GoTo                        http://howbigismybrowser.com/
     Sleep                       2                           # wait for browser
     SetConfig                   WindowSize                  550X550

--- a/test/acceptance/window.robot
+++ b/test/acceptance/window.robot
@@ -4,7 +4,7 @@ Library                         QWeb
 Library                         Collections
 Test Setup                      OpenBrowser                 about:blank                 ${BROWSER}                  --headless
 Test Teardown                   CloseBrowser
-Test Timeout                    20 seconds
+Test Timeout                    30 seconds
 
 *** Variables ***
 ${BROWSER}                      chrome


### PR DESCRIPTION
Workflows:
- Failure in a OS-workflow does no longer automatically fail other workflows on the same OS
- Acceptance tests -step timeouts after 30 minutes (recently some tests have halted completely for two hours)
- Added few new conditional steps - if acceptance tests fail
  - Rerun failed acceptance testsuites
  - Merge test results
- Updated external action dependencies
  - Checkout V2 -> V3
  - Setup-Python V2 -> V3

Acceptance tests:
- Tried to tighten test timeouts
  - Futile attempt, changed format from 1min to 60 seconds
  - browser.robot and window.robot timeouts were increased to 90 seconds
- Fixed IDE reference errors from acceptance tests by declaring "missing" variables at variables table

Rerun examples:
https://github.com/qentinelqi/qweb/actions/runs/2382295616
https://github.com/qentinelqi/qweb/actions/runs/2382295617