### PR TITLE
Safaridriver 15.5 raises TimeoutExceptions instead of expected exceptions

### DIFF
--- a/QWeb/internal/browser/safari.py
+++ b/QWeb/internal/browser/safari.py
@@ -19,6 +19,9 @@ def open_browser(port: int = 0,
     desired_capabilities = DesiredCapabilities.SAFARI
 
     driver = webdriver.Safari(port, executable_path, reuse_service, desired_capabilities, quiet)
+    # If implicit_wait is not > 0 Safaridriver starts raising TimeoutExceptions
+    #    instead of proper exception types
+    driver.implicitly_wait(0.1)
     driver.maximize_window()
     browser.cache_browser(driver)
     open_windows.append(driver.current_window_handle)


### PR DESCRIPTION
Safaridriver 15.5 started raising `TimeoutExceptions` instead of expected exceptions such as `InvalidSelectorException` and `NoSuchElementException`

Most likely this behavior is an unintented change to the driver.

Fixed by adding `driver.wait_implicitly(0.1)` to the _internal/browser/safari.py_ `open_browser()` method.
Solution is bit hacky but refactor for handling `TimeoutException` would affect all platforms and browsers and therefore could have unintended side effects