### PR TITLE
Limit acceptance-tests duty configurability

### DIFF
--- a/test/acceptance/icon.robot
+++ b/test/acceptance/icon.robot
@@ -13,7 +13,8 @@ ${BASE_IMAGE_PATH}          ${CURDIR}${/}..${/}resources${/}pics_and_icons${/}ic
 
 *** Test Cases ***
 Click icons
-    [Tags]                  ICON    PROBLEM_IN_MACOS
+    [Tags]                  ICON    PROBLEM_IN_MACOS    RESOLUTION_DEPENDENCY
+    Set Config              WindowSize   1920x1080
     ClickIcon               person                template_res_w=1920
     VerifyText              person is my tooltip value!
     ClickIcon               lock                  template_res_w=1920
@@ -34,7 +35,8 @@ Verify icons
 
 
 Click icons new screenshot
-    [Tags]                  ICON    PROBLEM_IN_MACOS
+    [Tags]                  ICON    PROBLEM_IN_MACOS    RESOLUTION_DEPENDENCY
+    Set Config              WindowSize   1920x1080
     ClickIcon               person                template_res_w=1920
     ClickIcon               power                 template_res_w=1920
     ClickText               Hide                  template_res_w=1920


### PR DESCRIPTION
Limit configurability which was added in another PR
Possible configurations:
- `duty acceptance-tests` -> runs tests with chrome and exits upon first failing test
- `duty acceptance-tests safari` runs tests with specified browser and exits upon first failing test
  - working browser names (case insensitive, depends on os availability):
    - Chrome (all OS)
    - Firefox (Win, Linux)
    - Edge (Win, Mac)
    - Safari (Mac)
- `duty acceptance-tests exitonfailure="false"` -> runs tests with chrome and does NOT exit  upon first failing test
- `duty acceptance-tests safari exitonfailure="false"` runs tests with specified browser and does NOT exit

Also added `RESOLUTION_DEPENDENCY` tag and added `SetConfig    WindowSize    1920x1080`  to two failing tests