### PR TITLE
Tko support dirs exec dirs

### DIFF
--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -124,7 +124,7 @@ def get_path(filename: str) -> Path:
     downloads = Path(get_downloads_dir()) / filename
     exec_dir = BuiltIn().get_variable_value('${EXECDIR}')
     files_exec_dir = Path(f"{get_exec_subdir(exec_dir, 'files')}/{filename}")
-    images_exec_dir = Path(f"{get_exec_subdir(exec_dir, 'images')}/{filename}") 
+    images_exec_dir = Path(f"{get_exec_subdir(exec_dir, 'images')}/{filename}")
     paths = [downloads, files, images, files_exec_dir, images_exec_dir]
 
     for path in paths:
@@ -156,9 +156,11 @@ def get_exec_subdir(base_path: str, target_dir: str) -> Path:
     -------
     str
     """
+    # pylint: disable=unused-variable
+    d = None
     for root, dirs, files in os.walk(base_path):
-        for dir in dirs:
-            if dir.lower() == target_dir:
-                return os.path.join(root, dir)
+        for d in dirs:
+            if d.lower() == target_dir:
+                return os.path.join(root, d)
 
-    return os.path.join(base_path, dir)
+    return os.path.join(base_path, d)

--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -122,7 +122,9 @@ def get_path(filename: str) -> Path:
     images = Path(
         BuiltIn().get_variable_value('${SUITE SOURCE}')).parent.parent / 'images' / filename
     downloads = Path(get_downloads_dir()) / filename
-    paths = [downloads, files, images]
+    files_exec_dir = Path(BuiltIn().get_variable_value('${EXECDIR}')) / 'files' / filename
+    images_exec_dir = Path(BuiltIn().get_variable_value('${EXECDIR}')) / 'images' / filename
+    paths = [downloads, files, images, files_exec_dir, images_exec_dir]
     for path in paths:
         if path.exists():
             logger.debug(path)

--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -122,10 +122,13 @@ def get_path(filename: str) -> Path:
     images = Path(
         BuiltIn().get_variable_value('${SUITE SOURCE}')).parent.parent / 'images' / filename
     downloads = Path(get_downloads_dir()) / filename
-    files_exec_dir = Path(BuiltIn().get_variable_value('${EXECDIR}')) / 'files' / filename
-    images_exec_dir = Path(BuiltIn().get_variable_value('${EXECDIR}')) / 'images' / filename
+    exec_dir = BuiltIn().get_variable_value('${EXECDIR}')
+    files_exec_dir = Path(f"{get_exec_subdir(exec_dir, 'files')}/{filename}")
+    images_exec_dir = Path(f"{get_exec_subdir(exec_dir, 'images')}/{filename}") 
     paths = [downloads, files, images, files_exec_dir, images_exec_dir]
+
     for path in paths:
+        logger.info(path, also_console=True)
         if path.exists():
             logger.debug(path)
             return path
@@ -136,3 +139,26 @@ def get_path(filename: str) -> Path:
     except TypeError as e:
         raise QWebFileNotFoundError(
             'File not found from default folders. Set variable for base image path') from e
+
+
+def get_exec_subdir(base_path: str, target_dir: str) -> Path:
+    """Finds a "special" subdirectory under execution dir.
+
+    Returns full path to special dir if found.
+    Returns base_path if special dir is not found.
+
+    Parameters
+    ----------
+    base_path : str
+    target_dir: str
+
+    Returns
+    -------
+    str
+    """
+    for root, dirs, files in os.walk(base_path):
+        for dir in dirs:
+            if dir.lower() == target_dir:
+                return os.path.join(root, dir)
+
+    return os.path.join(base_path, dir)

--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -141,7 +141,7 @@ def get_path(filename: str) -> Path:
             'File not found from default folders. Set variable for base image path') from e
 
 
-def get_exec_subdir(base_path: str, target_dir: str) -> Path:
+def get_exec_subdir(base_path: str, target_dir: str) -> str:
     """Finds a "special" subdirectory under execution dir.
 
     Returns full path to special dir if found.
@@ -163,4 +163,4 @@ def get_exec_subdir(base_path: str, target_dir: str) -> Path:
             if d.lower() == target_dir:
                 return os.path.join(root, d)
 
-    return os.path.join(base_path, d)
+    return os.path.join(base_path, target_dir)

--- a/QWeb/keywords/file.py
+++ b/QWeb/keywords/file.py
@@ -47,7 +47,7 @@ def use_pdf(filename: str) -> None:
     Parameters
     ----------
     filename : str
-        Default folders = users/downloads and project_dir/files.
+        Default folders = users/downloads, project_dir/files or ${EXECDIR}/**/files.
         Path is not needed if file is in default folder.
 
     Related keywords
@@ -74,7 +74,7 @@ def use_file(filename: str) -> None:
     Parameters
     ----------
     filename : str
-        Default folders = users/downloads and project_dir/files.
+        Default folders = users/downloads, project_dir/files or ${EXECDIR}/**/files.
         Path is not needed if file is in default folder.
 
     Related keywords

--- a/QWeb/keywords/input_.py
+++ b/QWeb/keywords/input_.py
@@ -682,7 +682,7 @@ def upload_file(locator: str,
     locator : str
         Text or index that locates the upload element.
     filename : file to upload
-        Default folders = users/downloads and project_dir/files
+        Default folders = users/downloads, project_dir/files or ${EXECDIR}/**/files
     anchor : str
         Index number or text near the input field's locator element.
         If the page contains many places where the locator is then anchor is used


### PR DESCRIPTION
Supports "default special folders" (files, images) being anywhere under ${EXECDIR}. This is needed for some services that start execution on unexpected parent folder.