### PR TITLE
Tko ios safari js

### DIFF
--- a/QWeb/internal/javascript.py
+++ b/QWeb/internal/javascript.py
@@ -157,6 +157,9 @@ def get_by_attributes(elements: list[WebElement], locator: str,
             var part = [];
             for (var i = 0; i < elems.length; i++) {
                var attrs = elems[i].attributes;
+               if (attrs == null){
+                continue;
+               }
                for (var j = 0; j < attrs.length; j++) {
                     if (attrs[j].value.trim() == locator) {
                         full.push(elems[i]);

--- a/QWeb/internal/javascript.py
+++ b/QWeb/internal/javascript.py
@@ -459,9 +459,10 @@ def get_text_elements_from_shadow_dom(locator: str, partial: bool) -> list[WebEl
     js = get_recursive_walk() + """
     function find_text_from_shadow_dom(text, partial){
         var results = [];
+        var unsupported_tags = ["script", "#document-fragment"]
         var elem = recursiveWalk(document.body, function(node) {
         //if (node.innerText == text) {
-        if (node.textContent.includes(text)) {
+        if (node.textContent.includes(text) && !unsupported_tags.includes(node.nodeName.toLowerCase())) {
             nodetext = [].reduce.call(node.childNodes, function(a, b) { return a + (b.nodeType === 3 ? b.textContent.trim() : ''); }, '');
             if (nodetext == text) {
                 results.push(node);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyScreeze>=0.1.28
 PyAutoGUI>=0.9.53
 Pillow==9.0.1
-robotframework>=3.2.2
+robotframework>=3.2.2,<6
 robotframework-debuglibrary==2.3.0
 selenium==4.1.0
 ply

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                       "pyautogui>=0.9.53",
                       "pynput>=1.7.6",
                       'requests>=2.27.0',
-                      "robotframework>=3.2.2",
+                      "robotframework>=3.2.2,<6",
                       "robotframework-debuglibrary==2.3.0",
                       "selenium==4.1.0",
                       "Pillow==9.0.1",


### PR DESCRIPTION
Few minor js fixes:
- handle "null" case in iOS/Safari
- filter out unneeded tags in shadow dom (text) search
- also locked max version of robot framework to 5.x for now