### PR TITLE
Suppress webdriver warnings

### DIFF
--- a/QWeb/internal/frame.py
+++ b/QWeb/internal/frame.py
@@ -184,7 +184,7 @@ def all_frames(fn: Callable[..., Any]) -> Callable[..., Any]:
                     driver.switch_to.frame(current_frame)
                     logger.debug('switching to childframe {}'.format(str(fn)))
                 except (StaleElementReferenceException, WebDriverException) as e:
-                    logger.warn(e)
+                    logger.debug(e)
                     driver.switch_to.default_content()
                     raise e
             try:
@@ -232,7 +232,7 @@ def all_frames(fn: Callable[..., Any]) -> Callable[..., Any]:
                     driver.switch_to.frame(current_frame)
                     logger.debug('switching to childframe {}'.format(str(fn)))
                 except (StaleElementReferenceException, WebDriverException) as e:
-                    logger.warn(e)
+                    logger.debug(e)
                     driver.switch_to.default_content()
                     raise e
             try:


### PR DESCRIPTION
`StaleElementReferenceError` and `WebDriverException` messages from decorator `frame.all_frames()` are being logged as warnings even though these do not lead to test failures. These warnings probably raise unnecessary concerns for the end users and should be suppressed by default.

![warning](https://user-images.githubusercontent.com/101569494/202713111-29917881-aebd-4ca0-aab4-fb1b7c2386dc.png)

Changing log level of these messages to debug instead of warn so that unnecessary stacktrace spam is not shown in the execution logs unless log level is set debug.