### PR TITLE
Initial

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["ubuntu-latest"]'
+      os: '["20.04"]'
       browser: '["chrome", "firefox"]'
       python-version: '["3.7", "3.8", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["20.04"]'
+      os: '["ubuntu-20.04"]'
       browser: '["chrome", "firefox"]'
       python-version: '["3.7", "3.8", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,7 +59,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux Firefox
-      # Ubuntu 22.04 image is missing FF and geckodriver
+      # ubuntu-latest (22.04, @28.11.2022) image is missing FF and geckodriver
+      # geckodriver install script from:
+      # https://gist.github.com/cgoldberg/4097efbfeb40adf698a7d05e75e0ff51
       if: matrix.os == 'ubuntu-latest'
       run: |
         install_dir="/usr/local/bin"

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -58,22 +58,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Setup Linux Firefox
-      # ubuntu-latest (22.04, @28.11.2022) image is missing FF and geckodriver
-      # geckodriver install script from:
-      # https://gist.github.com/cgoldberg/4097efbfeb40adf698a7d05e75e0ff51
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        install_dir="/usr/local/bin"
-        sudo apt-get install firefox
-        echo "Get DL URL"
-        json=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest)
-        url=$(echo "$json" | jq -r '.assets[].browser_download_url | select(contains("linux64")) | select(contains("asc") | not)')
-        echo "$url"
-        curl -s -L "$url" | tar -xz
-        chmod +x geckodriver
-        sudo mv geckodriver "$install_dir"
-
     - name: Setup Linux windowing
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux windowing
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -62,14 +62,15 @@ jobs:
       # Ubuntu 22.04 image is missing FF and geckodriver
       if: matrix.os == 'ubuntu-latest'
       run: |
+        install_dir="/usr/local/bin"
         sudo apt-get install firefox
+        echo "Get DL URL"
         json=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest)
-        url=$(echo "$json" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
+        url=$(echo "$json" | jq -r '.assets[].browser_download_url | select(contains("linux64")) | select(contains("asc") | not)')
+        echo "$url"
         curl -s -L "$url" | tar -xz
         chmod +x geckodriver
-        sudo mkdir /usr/local/share/geckodriver
-        sudo mv geckodriver /usr/local/share/geckodriver
-        PATH=$PATH:/usr/local/share/geckodriver
+        sudo mv geckodriver "$install_dir"
 
     - name: Setup Linux windowing
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -58,6 +58,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Setup Linux Firefox
+      # Ubuntu 22.04 image is missing FF and geckodriver
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install firefox
+        json=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest)
+        url=$(echo "$json" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
+        curl -s -L "$url" | tar -xz
+        chmod +x geckodriver
+        sudo mkdir /usr/local/share/geckodriver
+        sudo mv geckodriver /usr/local/share/geckodriver
+        PATH=$PATH:/usr/local/share/geckodriver
+
     - name: Setup Linux windowing
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -78,8 +78,8 @@ def timeout_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
                     if any(s in str(e) for s in FATAL_MESSAGES):
                         CONFIG.set_value("OSScreenshots", True)
                         raise QWebBrowserError(e)  # pylint: disable=W0707
-                    logger.info('From timeout decorator: Webdriver exception. Retrying..')
-                    logger.info(e)
+                    logger.debug('From timeout decorator: Webdriver exception. Retrying..')
+                    logger.debug(e)
                     time.sleep(SHORT_DELAY)
                     err = QWebDriverError
                     msg = e
@@ -132,14 +132,14 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
                 raise ve
             except (QWebStalingElementError, StaleElementReferenceException) as S:
                 if 'execute_click' in str(fn) or 'text_appearance' in str(fn):
-                    logger.info('Got staling element err from retry click.'
+                    logger.debug('Got staling element err from retry click.'
                                 'Action is probably triggered.')
                     raise QWebUnexpectedConditionError(S)  # pylint: disable=W0707
                 raise QWebStalingElementError('Staling element')  # pylint: disable=W0707
             except (WebDriverException, QWebDriverError) as wde:
                 if 'alert' in str(fn):
                     time.sleep(LONG_DELAY)
-                    logger.info("Got webdriver exception..{}. Retrying..".format(wde))
+                    logger.debug("Got webdriver exception..{}. Retrying..".format(wde))
                     err = QWebDriverError  # type: ignore[assignment]
                     msg = wde  # type: ignore[assignment]
                 else:

--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -42,7 +42,7 @@ def get_downloads_dir() -> str:
     """
     home_dir = platform.get_home_dir()
     download_dir = Path(home_dir) / 'Downloads'
-    logger.info('Downloads directory is {}'.format(download_dir))
+    logger.debug('Downloads directory is {}'.format(download_dir))
     return str(download_dir)
 
 
@@ -128,9 +128,9 @@ def get_path(filename: str) -> Path:
     paths = [downloads, files, images, files_exec_dir, images_exec_dir]
 
     for path in paths:
-        logger.info(path, also_console=True)
+        logger.debug(path, also_console=True)
         if path.exists():
-            logger.debug(path)
+            logger.debug(f"Path exists: {path}")
             return path
     try:
         base_path = BuiltIn().get_variable_value('${base_image_path}')

--- a/QWeb/internal/download.py
+++ b/QWeb/internal/download.py
@@ -128,7 +128,7 @@ def get_path(filename: str) -> Path:
     paths = [downloads, files, images, files_exec_dir, images_exec_dir]
 
     for path in paths:
-        logger.debug(path, also_console=True)
+        logger.debug(path)
         if path.exists():
             logger.debug(f"Path exists: {path}")
             return path

--- a/test/acceptance/download.robot
+++ b/test/acceptance/download.robot
@@ -25,6 +25,12 @@ Verify File Download Slow Bandwidth
 Verify File Download Fails If Multiple Files Found
     [Tags]    PROBLEM_IN_SAFARI
     VerifyText      Download small csv file
+    IF    "${BROWSER}"=="firefox"
+        Go To    about:config
+        Click Text    Accept the Risk and Continue
+        Type Text    Search preference name    browser.download.lastDir
+        Log Screenshot
+    END
     ExpectFileDownload
     Two Files Are Downloaded Without ExpectFileDownload Keyword
     Run Keyword And Expect Error    ValueError: Found more than one file that was modified

--- a/test/acceptance/download.robot
+++ b/test/acceptance/download.robot
@@ -25,12 +25,6 @@ Verify File Download Slow Bandwidth
 Verify File Download Fails If Multiple Files Found
     [Tags]    PROBLEM_IN_SAFARI
     VerifyText      Download small csv file
-    IF    "${BROWSER}"=="firefox"
-        Go To    about:config
-        Click Text    Accept the Risk and Continue
-        Type Text    Search preference name    browser.download.lastDir
-        Log Screenshot
-    END
     ExpectFileDownload
     Two Files Are Downloaded Without ExpectFileDownload Keyword
     Run Keyword And Expect Error    ValueError: Found more than one file that was modified

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -82,6 +82,7 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                      Frame
+    Set Config                  WindowSize                  1920x1080
     SetConfig                   CSSSelectors                off
     VerifyText                  CheckBox
     VerifyCheckboxStatus        I have a bike               enabled

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -82,8 +82,11 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                      Frame
-    Set Config                  WindowSize    1920x1080
     SetConfig                   CSSSelectors                off
+    # Headless FF on GH Actions has small viewport
+    # so we're going to move the frame viewport with VerifyText
+    # so that the checkboxes are visible
+    VerifyText    CheckBox
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled
     ClickCheckbox               I have a bike               on

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -83,21 +83,18 @@ Automatic frame search table elements
 Automatic frame search checkbox elements
     [Tags]                      Frame
     SetConfig                   CSSSelectors                off
-    # Headless FF on GH Actions has small viewport
-    # so we're going to move the frame viewport with VerifyText
-    # so that the checkboxes are visible
-    VerifyText    CheckBox
+    VerifyText                  CheckBox
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled
-    ClickCheckbox               I have a bike               on
-    ClickCheckbox               I have a bike               off
-    ClickCheckbox               I have a bike               on
-    ClickCheckbox               I have a bike               off
-    ClickCheckbox               I have a bike               on
+    ClickCheckbox               I have a bike               on            visibility=False
+    ClickCheckbox               I have a bike               off           visibility=False
+    ClickCheckbox               I have a bike               on            visibility=False
+    ClickCheckbox               I have a bike               off           visibility=False
+    ClickCheckbox               I have a bike               on            visibility=False
     VerifyCheckboxValue         I have a bike               on
-    ClickCheckbox               I have a car                on
+    ClickCheckbox               I have a car                on            visibility=False
     VerifyCheckboxValue         I have a car                on
-    ClickCheckbox               I have a car                off
+    ClickCheckbox               I have a car                off           visibility=False
     VerifyCheckboxValue         I have a car                off
 
 Automatic frame search dropdown elements

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -82,8 +82,9 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                      Frame
-    Set Config                  WindowSize                  1920x1080
+    SetConfig                   WindowSize                  1920x1080
     SetConfig                   CSSSelectors                off
+    RefreshPage
     VerifyText                  CheckBox
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -82,6 +82,7 @@ Automatic frame search table elements
 
 Automatic frame search checkbox elements
     [Tags]                      Frame
+    Set Config                  WindowSize    1920x1080
     SetConfig                   CSSSelectors                off
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled

--- a/test/acceptance/frame.robot
+++ b/test/acceptance/frame.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for frame keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}    --headless
+Suite Setup                     OpenBrowser                 file://${CURDIR}/../resources/frame.html                ${BROWSER}
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 
@@ -86,15 +86,15 @@ Automatic frame search checkbox elements
     VerifyText                  CheckBox
     VerifyCheckboxStatus        I have a bike               enabled
     VerifyCheckboxStatus        I should be disabled        disabled
-    ClickCheckbox               I have a bike               on            visibility=False
-    ClickCheckbox               I have a bike               off           visibility=False
-    ClickCheckbox               I have a bike               on            visibility=False
-    ClickCheckbox               I have a bike               off           visibility=False
-    ClickCheckbox               I have a bike               on            visibility=False
+    ClickCheckbox               I have a bike               on
+    ClickCheckbox               I have a bike               off
+    ClickCheckbox               I have a bike               on
+    ClickCheckbox               I have a bike               off
+    ClickCheckbox               I have a bike               on
     VerifyCheckboxValue         I have a bike               on
-    ClickCheckbox               I have a car                on            visibility=False
+    ClickCheckbox               I have a car                on
     VerifyCheckboxValue         I have a car                on
-    ClickCheckbox               I have a car                off           visibility=False
+    ClickCheckbox               I have a car                off
     VerifyCheckboxValue         I have a car                off
 
 Automatic frame search dropdown elements

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -12,8 +12,6 @@ ${BROWSER}    chrome
 InputElements
     [tags]                  inputsorder
     # Hover needed in ff 89
-    SetConfig               WindowSize      1920x1080
-    RefreshPage
     HoverText               Second input
     TypeText                Cell 1          Qentinel
     VerifyInputValue        field7          Qentinel  timeout=3
@@ -21,7 +19,7 @@ InputElements
     VerifyInputValue        field8          Robot
     TypeText                Cell 1 input:   Test Automation
     VerifyInputValue        field3          Test Automation
-    TypeText                Cell 1 input    FooBar      index=2
+    TypeText                Cell 1 input    FooBar      index=2         visibility=False
     VerifyInputValue        field3          FooBar
 
 CheckboxElements

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -13,6 +13,7 @@ InputElements
     [tags]                  inputsorder
     # Hover needed in ff 89
     SetConfig               WindowSize      1920x1080
+    RefreshPage
     HoverText               Second input
     TypeText                Cell 1          Qentinel
     VerifyInputValue        field7          Qentinel  timeout=3

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -23,6 +23,8 @@ InputElements
     VerifyInputValue        field3          FooBar
 
 CheckboxElements
+    SetConfig               WindowSize              1920x1080
+    RefreshPage
     ClickCheckbox           I have a                on
     VerifyCheckboxValue     I have a bike           on
     ClickCheckbox           Sample text             on

--- a/test/acceptance/searchingorder.robot
+++ b/test/acceptance/searchingorder.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
-Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser  file://${CURDIR}/../resources/frame.html  ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 
@@ -12,6 +12,7 @@ ${BROWSER}    chrome
 InputElements
     [tags]                  inputsorder
     # Hover needed in ff 89
+    SetConfig               WindowSize      1920x1080
     HoverText               Second input
     TypeText                Cell 1          Qentinel
     VerifyInputValue        field7          Qentinel  timeout=3


### PR DESCRIPTION
Retry loops should not spam into console or info level log.

Changed a few `logger.info()` calls to `logger.debug()` calls to remove unnecessary messages from console and info level

Change at line 135 should be paid attention to. That exception handling block raises after logging so it might be reasonable to log at info level because the loop should stop after the raise.

![image](https://user-images.githubusercontent.com/101569494/203773537-f1ec9d29-8561-4728-b61a-468b2d37923b.png)

**This PR also includes a GitHub Action fix for ubuntu-latest currently missing Firefox & Geckodriver**
