### PR TITLE
Fix unbound local error with text anchors

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/QWeb/internal/decorators.py
+++ b/QWeb/internal/decorators.py
@@ -133,7 +133,7 @@ def timeout_decorator_for_actions(fn: Callable[..., Any]) -> Callable[..., Any]:
             except (QWebStalingElementError, StaleElementReferenceException) as S:
                 if 'execute_click' in str(fn) or 'text_appearance' in str(fn):
                     logger.debug('Got staling element err from retry click.'
-                                'Action is probably triggered.')
+                                 'Action is probably triggered.')
                     raise QWebUnexpectedConditionError(S)  # pylint: disable=W0707
                 raise QWebStalingElementError('Staling element')  # pylint: disable=W0707
             except (WebDriverException, QWebDriverError) as wde:

--- a/QWeb/internal/text.py
+++ b/QWeb/internal/text.py
@@ -285,6 +285,8 @@ def get_element_using_anchor(elements: list[WebElement], anchor: Optional[Union[
                 if len(anchor_elements) > 0:
                     logger.debug('No exact match found, using first partial match')
                     anchor_element = anchor_elements[0]
+                else:
+                    raise QWebElementNotFoundError(f"Could not find elements for anchor: {anchor}")
         else:
             anchor_element = get_unique_text_element(anchor, **kwargs)
         return element.get_closest_element(anchor_element, elements)


### PR DESCRIPTION
If config `MultipleAnchors==True` and no anchors are found in method `QWeb/internal/text.py - get_element_using_anchor()` then an `UnboundLocalError` raises due to missing handling for the condition.

Fixed by adding a check which now raises more appropriate exception `QWebElementNotFound` if no anchors are found.

Also includes a minor linting fix to `QWeb/internal/decorators.py - perform()`