### PR TITLE
Save screenshot fix

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -18,6 +18,6 @@ jobs:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
       os: '["ubuntu-20.04"]'
-      browser: '["chrome", "firefox"]'
+      browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.7", "3.8", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["ubuntu-latest"]'
+      os: '["ubuntu-20.04"]'
       browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.7", "3.8", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["ubuntu-20.04"]'
+      os: '["ubuntu-latest"]'
       browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.7", "3.8", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["ubuntu-20.04"]'
+      os: '["ubuntu-latest"]'
       browser: '["chrome", "firefox", "edge"]'
-      python-version: '["3.7", "3.8", "3.9"]'
+      python-version: '["3.7", "3.9"]'
       rfw-322-python: "3.7"

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
+        xauth generate  :$DISPLAY .
         matchbox-window-manager -use_titlebar no &
         pip install python-xlib
 
@@ -85,9 +86,9 @@ jobs:
       run: |
         python -m pip show robotframework
 
-    # - name: Display screen resolution
-    #   run: |
-    #     python -c "import pyautogui; print(pyautogui.size())"
+     - name: Display screen resolution
+       run: |
+         python -c "import pyautogui; print(pyautogui.size())"
 
     - name: Unit tests
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,12 +59,17 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux windowing
-      if: matrix.os == 'ubuntu-20.04'
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get install matchbox scrot
-        Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        matchbox-window-manager -use_titlebar no &
         pip install python-xlib
+        Xvfb $DISPLAY -screen 0 1920x1080x24 &
+        sleep 1
+        matchbox-window-manager -use_titlebar no &
+        touch /home/runner/.Xauthority
+        pushd /home/runner
+        xauth generate $DISPLAY .
+        popd
 
     - name: Install RFW 3.2.2
       if: matrix.python-version == inputs.rfw-322-python
@@ -85,13 +90,13 @@ jobs:
       run: |
         python -m pip show robotframework
 
-    # - name: Display screen resolution
-    #   run: |
-    #     python -c "import pyautogui; print(pyautogui.size())"
+    - name: Display screen resolution
+      run: | 
+        python -c "import pyautogui; print(pyautogui.size())"
 
     - name: Unit tests
       run: |
-        pytest -v --junit-xml=unittests.xml --cov=QWeb
+       pytest -v --junit-xml=unittests.xml --cov=QWeb
 
     - name: Acceptance tests
       id: initial-acceptance-tests

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        xauth generate $DISPLAY .
+        xauth list
         matchbox-window-manager -use_titlebar no &
         pip install python-xlib
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        xauth list
+        xauth generate $DISPLAY .
         matchbox-window-manager -use_titlebar no &
         pip install python-xlib
 
@@ -88,7 +88,7 @@ jobs:
 
      - name: Display screen resolution
        run: |
-         python -c "import pyautogui; print(pyautogui.size())"
+        python -c "import pyautogui; print(pyautogui.size())"
 
     - name: Unit tests
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -86,8 +86,8 @@ jobs:
       run: |
         python -m pip show robotframework
 
-     - name: Display screen resolution
-       run: |
+    - name: Display screen resolution
+      run: |
         python -c "import pyautogui; print(pyautogui.size())"
 
     - name: Unit tests

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,7 +63,10 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        xauth generate $DISPLAY .
+        sudo mv $HOME/.Xauthority $HOME/old.Xauthority
+        touch $HOME/.Xauthority
+        xauth generate $DISPLAY . trusted
+        xauth add ${HOST}$DISPLAY . $(xxd -l 16 -p /dev/urandom)
         matchbox-window-manager -use_titlebar no &
         pip install python-xlib
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,12 +59,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux windowing
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
         matchbox-window-manager -use_titlebar no &
-        xauth list
         pip install python-xlib
 
     - name: Install RFW 3.2.2

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,12 +59,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux windowing
-      if: matrix.os == 'Linux'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
         matchbox-window-manager -use_titlebar no &
-        touch /home/runner/.Xauthority
         pip install python-xlib
 
     - name: Install RFW 3.2.2

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,11 +63,8 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        sudo mv $HOME/.Xauthority $HOME/old.Xauthority
-        touch $HOME/.Xauthority
-        xauth generate $DISPLAY . trusted
-        xauth add ${HOST}$DISPLAY . $(xxd -l 16 -p /dev/urandom)
         matchbox-window-manager -use_titlebar no &
+        xauth list
         pip install python-xlib
 
     - name: Install RFW 3.2.2

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -85,9 +85,9 @@ jobs:
       run: |
         python -m pip show robotframework
 
-    - name: Display screen resolution
-      run: |
-        python -c "import pyautogui; print(pyautogui.size())"
+    # - name: Display screen resolution
+    #   run: |
+    #     python -c "import pyautogui; print(pyautogui.size())"
 
     - name: Unit tests
       run: |

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
-        xauth generate  :$DISPLAY .
+        xauth generate $DISPLAY .
         matchbox-window-manager -use_titlebar no &
         pip install python-xlib
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -59,11 +59,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Linux windowing
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'Linux'
       run: |
         sudo apt-get install matchbox scrot
         Xvfb $DISPLAY -screen 0 1920x1080x24 & sleep 1
         matchbox-window-manager -use_titlebar no &
+        touch /home/runner/.Xauthority
         pip install python-xlib
 
     - name: Install RFW 3.2.2

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -19,7 +19,7 @@ jobs:
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
       os: '["windows-latest"]'
       browser: '["chrome", "edge", "firefox"]'
-      python-version: '["3.10", "3.11"]'
+      python-version: '["3.9", "3.10"]'
       rfw-322-python: "3.9"
       rfw-exclude-tags: "-e FLASK"
       

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -19,7 +19,7 @@ jobs:
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
       os: '["windows-latest"]'
       browser: '["chrome", "edge", "firefox"]'
-      python-version: '["3.9", "3.10"]'
+      python-version: '["3.10", "3.11"]'
       rfw-322-python: "3.9"
       rfw-exclude-tags: "-e FLASK"
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,13 @@ duty lint
 
 ...on repo root.
 
+##### Typing
+We use *mypy* for typechecking. To run typechecking locally, run:
+
+```bash
+duty typing
+```
+
 ##### Unit tests
 
 We use **pytest** for unit tests. Unit tests are located in `/test/unit` folder. You can run unit test locally by running command:

--- a/QWeb/internal/screenshot.py
+++ b/QWeb/internal/screenshot.py
@@ -202,6 +202,12 @@ def save_screenshot(filename: str = 'screenshot_{}.png',
 
     filepath = os.path.join(screen_shot_dir, filename)
 
+    try:
+        driver = browser.get_current_browser()
+    except (WebDriverException, QWebDriverError):
+        driver = None
+        config.set_config("OSScreenshots", True)
+
     if pyautog is True or config.get_config("OSScreenshots"):
         # try to remove image, needed for scrot > 0.9
         try:
@@ -212,10 +218,6 @@ def save_screenshot(filename: str = 'screenshot_{}.png',
         pyscreenshot(filepath)
         logger.info('Saved screenshot to {}'.format(filepath))
         return filepath
-    try:
-        driver = browser.get_current_browser()
-    except WebDriverException:
-        driver = None
 
     if driver:
         saved: Union[str, bool]

--- a/QWeb/internal/screenshot.py
+++ b/QWeb/internal/screenshot.py
@@ -204,7 +204,7 @@ def save_screenshot(filename: str = 'screenshot_{}.png',
 
     try:
         driver = browser.get_current_browser()
-    except (WebDriverException, QWebDriverError):
+    except QWebDriverError:
         driver = None
         config.set_config("OSScreenshots", True)
 

--- a/test/acceptance/browser.robot
+++ b/test/acceptance/browser.robot
@@ -24,6 +24,11 @@ Close All Browsers 2
     OpenBrowser     about:blank             firefox         # force another (firefox) browser to open
     [Teardown]      CloseAllBrowsers
 
+Missing webdriver message
+    [Tags]        PROBLEM_IN_MACOS
+    [Setup]    No Operation
+    Run Keyword and Expect Error    SafariDriver was not found*    OpenBrowser    about:blank    safari
+
 No browser open message
     ${previous}=    SetConfig               LogScreenshot    False
     CloseAllBrowsers
@@ -108,7 +113,7 @@ Open Browser in mobile emulation mode
     OpenBrowser     http://howbigismybrowser.com/     ${BROWSER}    emulation=iPhone SE
     Log Screenshot
     CloseBrowser
-    Run Keyword And Expect Error    QWebDriverError: *
+    Run Keyword And Expect Error    InvalidArgumentException: *
     ...     OpenBrowser     about:blank     ${BROWSER}    emulation=should not be found
 
     Close Browsers And Remove CHROME_ARGS

--- a/test/acceptance/download.robot
+++ b/test/acceptance/download.robot
@@ -40,7 +40,7 @@ Verify File Download Fail No File Downloading
 
 
 Verify File Download Fail Timeout
-    [Tags]    PROBLEM_IN_SAFARI		PROBLEM_IN_FIREFOX
+    [Tags]    PROBLEM_IN_SAFARI		PROBLEM_IN_FIREFOX  PROBLEM_IN_EDGE
     VerifyText      Download small csv file
     ExpectFileDownload
     ClickText       Download large csv file


### PR DESCRIPTION
Commit [](https://github.com/qentinelqi/qweb/commit/95aef97a9534f547dc252e66a211caf0b6836602) which contained typing fixes and streamlined handling of nonexistent browser introduced a bug which caused missing browser executable and missing webdriver exceptions to misleadingly show up as `QWebDriverError("No browser open. Use OpenBrowser keyword to open browser first")`

Another side effect was that in such situations fallback `OSScreenshot` was not used to get information about the execution environment.

PR contains
- a fix to these cases
- a test to browser.robot which checks that a missing safari webdriver (in Windows and Linux) shows up correctly
- fix to a test in `Open Browser in mobile emulation mode` at browser.robot which was relying on the wrong exception when trying to start a nonexistent emulation mode
- added info about `duty typing` to CONTRIBUTING.md

There are a lot of places where `if get_current_browser() is None` is unnecessarily checked (due to the mentioned streamlining) but these should be cleaned up in a separate PR