### PR TITLE
break from loop when matching attribute is found

### DIFF
--- a/QWeb/internal/javascript.py
+++ b/QWeb/internal/javascript.py
@@ -163,9 +163,11 @@ def get_by_attributes(elements: list[WebElement], locator: str,
                for (var j = 0; j < attrs.length; j++) {
                     if (attrs[j].value.trim() == locator) {
                         full.push(elems[i]);
+                        break;
                     }
                     else if (partial && attrs[j].value.includes(locator)){
                         part.push(elems[i]);
+                        break;
                     }
                }
             }


### PR DESCRIPTION
Fixes issue that came up with Chrome 115 -> driver throwing an exception if same element is added to a list multiple times