### PR TITLE
http serverless execution of acceptance tests

### DIFF
--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -30,7 +30,7 @@ on:
       additional-rfw-parameters:
         description: Execution parameters which will be added to RFW execution. For example "-v customvar:somevalue"
         required: false
-        default: ""
+        default: "-v ON_HTTP_SERVER:True"
         type: string
 
 jobs:

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -105,9 +105,7 @@ jobs:
       with:
         directory: test/resources
         port: 8000
-        
-      #run: |
-      #  python -m http.server -b 127.0.0.1 -d test/resources 8000 &
+
   
     # if this test suite fails then a proper test run won't be attempted
     - name: Safari smoke test
@@ -117,6 +115,7 @@ jobs:
         python -m robot
         -o safari_smoke.xml
         -v BROWSER:${{ matrix.browser }}
+        -v ON_HTTP_SERVER:True
         -L TRACE
         -d result
         --name ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}

--- a/duties.py
+++ b/duties.py
@@ -108,6 +108,7 @@ def acceptance_tests(ctx,
                f" {listener_cmd}"
                f" {cmd_exit_on_failure}"
                f" -v BROWSER:{browser}"
+               f" -v ON_HTTP_SERVER:True"
                f" {cmd_excludes}"
                f" test/acceptance")
         

--- a/test/acceptance/__init__.robot
+++ b/test/acceptance/__init__.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Suite Setup    Check Http Server
+
+*** Variables ***
+${ON_HTTP_SERVER}=    ${FALSE}
+
+*** Keywords ***
+Check Http Server
+    IF    $ON_HTTP_SERVER
+        ${BASE_URI}=    Set Variable    http://127.0.0.1:8000
+    ELSE
+        ${BASE_URI}=    Set Variable    file:///${CURDIR}/../resources
+    END
+    Set Global Variable    ${BASE_URI}

--- a/test/acceptance/parallel/ClickItem.robot
+++ b/test/acceptance/parallel/ClickItem.robot
@@ -2,7 +2,7 @@
 Documentation       Test for ClickItem keyword
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
-Test Setup          GoTo    http://127.0.0.1:8000/items.html
+Test Setup          GoTo    ${BASE_URI}/items.html
 Suite Teardown      CloseBrowser
 Test Timeout        60 seconds
 

--- a/test/acceptance/parallel/accordion.robot
+++ b/test/acceptance/parallel/accordion.robot
@@ -2,7 +2,7 @@
 Documentation       Tests for text in html5 accordion elements
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}    --headless
-Test Setup          GoTo    http://127.0.0.1:8000/accordions_and_modals.html
+Test Setup          GoTo    ${BASE_URI}/accordions_and_modals.html
 Suite Teardown      CloseBrowser
 Test Timeout        120 seconds
 

--- a/test/acceptance/parallel/alert.robot
+++ b/test/acceptance/parallel/alert.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for handling of alerts
 Library           QWeb
-Suite Setup       OpenBrowser    http://127.0.0.1:8000/alert.html    ${BROWSER}   --headless
+Suite Setup       OpenBrowser    ${BASE_URI}/alert.html    ${BROWSER}   --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/browser_headless.robot
+++ b/test/acceptance/parallel/browser_headless.robot
@@ -43,18 +43,18 @@ No browser open message
 
 ScrollText
     [Teardown]    CloseAllBrowsers
-    GoTo            http://127.0.0.1:8000/input.html
+    GoTo            ${BASE_URI}/input.html
     ScrollText      UpDown
 
 SwitchBrowser
     [Tags]          PROBLEM_IN_WINDOWS    PROBLEM_IN_MACOS
-    GoTo            http://127.0.0.1:8000/multielement_text.html
+    GoTo            ${BASE_URI}/multielement_text.html
     IF    $HEADLESS
-        OpenBrowser     http://127.0.0.1:8000/dropdown.html     chrome    --headless
-        OpenBrowser     http://127.0.0.1:8000/frame.html        firefox   --headless
+        OpenBrowser     ${BASE_URI}/dropdown.html     chrome    --headless
+        OpenBrowser     ${BASE_URI}/frame.html        firefox   --headless
     ELSE
-        OpenBrowser     http://127.0.0.1:8000/dropdown.html     chrome
-        OpenBrowser     http://127.0.0.1:8000/frame.html        firefox
+        OpenBrowser     ${BASE_URI}/dropdown.html     chrome
+        OpenBrowser     ${BASE_URI}/frame.html        firefox
     END
     VerifyText      Text in frame
     SwitchBrowser   1

--- a/test/acceptance/parallel/checkbox.robot
+++ b/test/acceptance/parallel/checkbox.robot
@@ -2,7 +2,7 @@
 Documentation     Tests for handling of checkboxes
 Library           QWeb
 Library           Dialogs
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/checkbox.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/checkbox.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 
@@ -101,5 +101,5 @@ No Text Found
     Should Contain  ${msg}  QWebElementNotFoundError: Unable to find element for locator
 
 No Checkbox found
-    GoTo                    http://127.0.0.1:8000/text.html
+    GoTo                    ${BASE_URI}/text.html
     Run Keyword And Expect Error       QWebElementNotFoundError: Unable*   ClickCheckbox   Lorem   On       1       2

--- a/test/acceptance/parallel/cli.robot
+++ b/test/acceptance/parallel/cli.robot
@@ -3,7 +3,6 @@ Documentation             Tests for QWeb command line interface
 Library                   QWeb
 Library                   Process
 Suite Setup               Get Python executable
-Suite Teardown            Terminate All Processes
 Test Timeout              60 seconds
 
 *** Variables ***

--- a/test/acceptance/parallel/config.robot
+++ b/test/acceptance/parallel/config.robot
@@ -5,7 +5,7 @@ Test Timeout      60 seconds
 
 *** Variables ***
 ${BROWSER}    chrome
-${URL}        http://127.0.0.1:8000/checkbox.html
+${URL}        ${BASE_URI}/checkbox.html
 
 *** Test Cases ***
 Test ScreenshotType Config

--- a/test/acceptance/parallel/dropdown.robot
+++ b/test/acceptance/parallel/dropdown.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for Dropdown keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/dropdown.html            ${BROWSER}    --headless
+Suite Setup                     OpenBrowser                 ${BASE_URI}/dropdown.html            ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 

--- a/test/acceptance/parallel/element.robot
+++ b/test/acceptance/parallel/element.robot
@@ -2,7 +2,7 @@
 Documentation                   Tests from element keywords
 Library                         QWeb
 Library                         OperatingSystem
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/text.html                 ${BROWSER}           --headless
+Suite Setup                     OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}           --headless
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 
@@ -50,26 +50,26 @@ Click Element by xpath 2
     VerifyText                  Button4 was clicked
 
 Click Element by xpath 3
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     Verify No Text              Button4 was clicked
     ClickElement                xpath=//*[@value\="Button4"]
     VerifyText                  Button4 was clicked
 
 Click Element by xpath 4
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     Verify No Text              Button4 was clicked
     ClickElement                xpath=//*[@value="Button4"]
     VerifyText                  Button4 was clicked
 
 Click Element by xpath and index
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     Verify No Text              Signup near Random text was clicked
     ClickElement                //input[@value\="Signup"]    index=2
     VerifyText                  Signup near Random text was clicked
 
 Click Element by WebElement instance
     [Tags]                      WebElement
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${elem}=                    GetWebElement               Button4                        element_type=text
     ClickElement                ${elem}
     VerifyText                  Button4 was clicked
@@ -131,7 +131,7 @@ Use attributes without xpath to get element
 
 GetElementCountOK
     [Tags]                      GetElementCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${count}                    GetElementCount             button                      tag=input
     should be equal             ${count}                    ${5}
     ${count}                    GetElementCount             //img
@@ -139,7 +139,7 @@ GetElementCountOK
 
 GetAttributeOK
     [Tags]                      GetAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${attribute}                GetAttribute                SkimClick disable button    id                          element_type=Text
     should be equal             ${attribute}                skimclick
     ${attribute}                GetAttribute                //img                       data-icon
@@ -156,7 +156,7 @@ GetAttributeOK
 
 GetAttributeNOK
     [Tags]                      GetAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     Run Keyword And Expect Error    QWebElementNotFoundError:*    GetAttribute         //button[@name\="somethingthatdoesnotexist"]    id    timeout=2
     Run Keyword And Expect Error    QWebValueError:*              GetAttribute         //button                                        id    timeout=2
     # jailed, Chrome 123
@@ -164,7 +164,7 @@ GetAttributeNOK
 
 VerifyAttributeOK
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyAttribute             SkimClick disable button    id                          skimclick                   element_type=Text
     VerifyAttribute             //img                       data-icon                   screen
     VerifyAttribute             reset                       value                       Button4                     element_type=item
@@ -175,14 +175,14 @@ VerifyAttributeOK
 
 VerifyAttributeNotEquals
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyAttribute             SkimClick disable button    id                          skimclick123                element_type=Text    operator=not equal
     VerifyAttribute             SkimClick disable button    id                          skimclick123                element_type=Text    operator=!=
     VerifyAttribute             //img                       data-icon                   screen123                   operator=not equal  
 
 VerifyAttributeGreater
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # greater, should pass
     VerifyAttribute             Button3    data-id                          7                   element_type=Text    operator=greater than
     VerifyAttribute             Button3    data-id                          5                   element_type=Text    operator=>
@@ -193,7 +193,7 @@ VerifyAttributeGreater
 
 VerifyAttributeGreaterOrEqual
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # greater or equal, should pass
     VerifyAttribute             Button3    data-id                          7                   element_type=Text    operator=greater than or equal
     VerifyAttribute             Button3    data-id                          12345               element_type=Text    operator=>=
@@ -202,7 +202,7 @@ VerifyAttributeGreaterOrEqual
 
 VerifyAttributeLessThan
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # lower, should pass
     VerifyAttribute             input[value\="Button3"]     data-id                     12347                   element_type=css        operator=less than
     VerifyAttribute             input[value\="Button3"]     data-id                     12347                   element_type=css        operator=<
@@ -213,7 +213,7 @@ VerifyAttributeLessThan
 
 VerifyAttributeLessThanOrEqual
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # lower or equal, should pass
     VerifyAttribute             input[value\="Button3"]     data-id                     12347                   element_type=css        operator=less than or equal
     VerifyAttribute             input[value\="Button3"]     data-id                     12345                   element_type=css        operator=<=
@@ -222,7 +222,7 @@ VerifyAttributeLessThanOrEqual
 
 VerifyAttributeContains
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # contains, should pass
     VerifyAttribute             SkimClick disable button    id                          skim      element_type=Text   operator=contains
     VerifyAttribute             input[value\="Button3"]     data-id                     123                     element_type=css        operator=contains
@@ -231,7 +231,7 @@ VerifyAttributeContains
 
 VerifyAttributeNotContains
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # contains, should pass
     VerifyAttribute             SkimClick disable button    id                          skjm      element_type=Text   operator=not contains
     VerifyAttribute             input[value\="Button3"]     data-id                     3245                     element_type=css        operator=not contains
@@ -240,7 +240,7 @@ VerifyAttributeNotContains
 
 VerifyAttributeIncorrectOperator
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     # default operator
     VerifyAttribute             SkimClick disable button    id                          skimclick                   element_type=Text 
     # incorrect operator
@@ -250,7 +250,7 @@ VerifyAttributeIncorrectOperator
 
 VerifyAttributeCheckbox
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/checkbox.html
+    Go To                       ${BASE_URI}/checkbox.html
     ClickText                   Blue
     VerifyAttribute             //*[@id\="ch_1_1"]          checked                     true
     ClickText                   Blue
@@ -258,7 +258,7 @@ VerifyAttributeCheckbox
 
 VerifyAttributeNOK
     [Tags]                      VerifyAttribute
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     Run Keyword And Expect Error      QWebElementNotFoundError:*    VerifyAttribute      //button[@name\="somethingthatdoesnotexist"]    id    something    timeout=2
     Run Keyword And Expect Error      QWebValueError:*              VerifyAttribute      //button             value                Button2              element_type=Text    timeout=2
     # not valid css
@@ -269,7 +269,7 @@ VerifyAttributeNOK
 
 VerifyElementTextBorders
     [Tags]                      VerifyElementText    DrawBorders
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     
     ${no_border_file}           SetVariable            ${CURDIR}/no_border.png
     ${with_border_file}         SetVariable            ${CURDIR}/with_border.png

--- a/test/acceptance/parallel/element_corners.robot
+++ b/test/acceptance/parallel/element_corners.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for corner
 Library           QWeb
-Suite Setup       OpenBrowser    http://127.0.0.1:8000/corners.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser    ${BASE_URI}/corners.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/frame.robot
+++ b/test/acceptance/parallel/frame.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for frame keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/frame.html                ${BROWSER}    --headless
+Suite Setup                     OpenBrowser                 ${BASE_URI}/frame.html                ${BROWSER}    --headless
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 

--- a/test/acceptance/parallel/input_headless.robot
+++ b/test/acceptance/parallel/input_headless.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for input keywords
 Library          QWeb
 Library          OperatingSystem
-Suite Setup      OpenBrowser    http://127.0.0.1:8000/input.html    ${BROWSER}  --headless
+Suite Setup      OpenBrowser    ${BASE_URI}/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseAllBrowsers
 Test Timeout     60 seconds
 
@@ -247,21 +247,21 @@ Search Direction All Directions
 No Textbox found
     [Tags]                  jailed
     # jailed due to Chrome 123 bug
-    GoTo                    http://127.0.0.1:8000/input.html
+    GoTo                    ${BASE_URI}/input.html
     Run Keyword And Expect Error       QWebElementNotFoundError: Unable to find*
     ...   TypeText   Lorem   foo   1   3
 
 No Textboxes on page
     [Tags]                  jailed
     # jailed due to Chrome 123 bug
-    GoTo                    http://127.0.0.1:8000/text.html
+    GoTo                    ${BASE_URI}/text.html
     Run Keyword And Expect Error    QWebElementNotFoundError: Unable to find*
     ...   TypeText                  HoverDropdown    Qwerty     timeout=2
 
 Secret
     [documentation]         Test secrets handling. It is recommended to provide any secrets
     ...                     as variables outside the script.
-    GoTo                    http://127.0.0.1:8000/input.html
+    GoTo                    ${BASE_URI}/input.html
     # Testing purposes only
     ${SECRET}               Set Variable            sdfpv98xddv097vsdxv97
     # Recommended, secret is provided as variable OUTSIDE of the test script and version control.
@@ -274,7 +274,7 @@ Secret
 Secret Without Debug Logs When Debugfile Option Used
     [documentation]         Test secrets when -b/--debugfile option is used.
     [Tags]                  WITH_DEBUGFILE
-    GoTo                    http://127.0.0.1:8000/input.html
+    GoTo                    ${BASE_URI}/input.html
     TypeSecret              First input           fdfsdf98723fdkjc9vsdv222
     TypeSecret3             First input           223423423423423432
     TypeText                Second input          View this text in debug file

--- a/test/acceptance/parallel/javascript.robot
+++ b/test/acceptance/parallel/javascript.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Javascript keyword
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/javascript.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/javascript.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/lists.robot
+++ b/test/acceptance/parallel/lists.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for table keywords
 Library          QWeb
 Library          Collections
-Suite Setup      OpenBrowser  http://127.0.0.1:8000/lists.html  ${BROWSER}  --headless
+Suite Setup      OpenBrowser  ${BASE_URI}/lists.html  ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
 Test Timeout     60 seconds
 

--- a/test/acceptance/parallel/no_body.robot
+++ b/test/acceptance/parallel/no_body.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Test for selecting active xpath
 Library           QWeb
-Suite Setup       OpenBrowser    http://127.0.0.1:8000/no_body.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser    ${BASE_URI}/no_body.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      20 seconds
 

--- a/test/acceptance/parallel/paceblock.robot
+++ b/test/acceptance/parallel/paceblock.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for input keywords
 Library          QWeb
 Library          OperatingSystem
-Suite Setup      OpenBrowser    http://127.0.0.1:8000/input.html    ${BROWSER}  --headless
+Suite Setup      OpenBrowser    ${BASE_URI}/input.html    ${BROWSER}  --headless
 Suite Teardown   CloseBrowser
 Test Timeout     60 seconds
 
@@ -19,12 +19,12 @@ Run Block basic robot kw without arguments used as PaceBlock
 
 Run Block basic robot kw with arguments used as PaceBlock
     [tags]                  PROBLEM_IN_FIREFOX
-    Goto                    http://127.0.0.1:8000/text.html
+    Goto                    ${BASE_URI}/text.html
     RunBlock                Clicks      Clicks: 5      timeout=15
 
 RunBlock For loop in robot kw
     [tags]                  PROBLEM_IN_FIREFOX
-    Goto                    http://127.0.0.1:8000/input.html
+    Goto                    ${BASE_URI}/input.html
     RefreshPage
     RunBlock                TypeThreeTimes    timeout=5
 
@@ -35,7 +35,7 @@ Appstate without argument
 
 Appstate with argument
     [tags]              Appstate
-    Goto                  http://127.0.0.1:8000/text.html
+    Goto                  ${BASE_URI}/text.html
     RefreshPage
     Appstate            Clicks              Clicks: 1
     VerifyText          Clicks: 1
@@ -60,7 +60,7 @@ FooBarBaz
     VerifyInputValue      The Brave          TestTestTest    timeout=0.5s
 
 Clickbutton
-    Goto                  http://127.0.0.1:8000/text.html
+    Goto                  ${BASE_URI}/text.html
     RefreshPage
     ClickText             Click me      #Every click = + 1 to counter
 

--- a/test/acceptance/parallel/searchingorder.robot
+++ b/test/acceptance/parallel/searchingorder.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/frame.html  ${BROWSER}    --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/frame.html  ${BROWSER}    --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/searchorder_config.robot
+++ b/test/acceptance/parallel/searchorder_config.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Full matches should always be first if text-attr is not used
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/text.html  ${BROWSER}    --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/text.html  ${BROWSER}    --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/selectors.robot
+++ b/test/acceptance/parallel/selectors.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for selector attribute
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/frame.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/frame.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/self_repairing_input.robot
+++ b/test/acceptance/parallel/self_repairing_input.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Library        QWeb
 Documentation  Regression test for self repairing input, this Fails if input field loses focus right after clear
-Suite Setup    OpenBrowser  http://127.0.0.1:8000/self_repairing_example.html  ${BROWSER}  --headless
+Suite Setup    OpenBrowser  ${BASE_URI}/self_repairing_example.html  ${BROWSER}  --headless
 Suite Teardown  CloseBrowser
 Test Timeout        60 seconds
 

--- a/test/acceptance/parallel/table.robot
+++ b/test/acceptance/parallel/table.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for table keywords
 Library          QWeb
 Library          Collections
-Suite Setup      OpenBrowser    http://127.0.0.1:8000/table.html  ${BROWSER}  --headless      
+Suite Setup      OpenBrowser    ${BASE_URI}/table.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
 Test Timeout     60 seconds
 

--- a/test/acceptance/parallel/table2.robot
+++ b/test/acceptance/parallel/table2.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     More tests for table keywords
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/table2.html  ${BROWSER}  --headless
+Suite Setup       OpenBrowser  ${BASE_URI}/table2.html  ${BROWSER}  --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
 

--- a/test/acceptance/parallel/table3.robot
+++ b/test/acceptance/parallel/table3.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for table keywords
 Library          QWeb
 Library          Collections
-Suite Setup      OpenBrowser    http://127.0.0.1:8000/table3.html  ${BROWSER}  --headless      
+Suite Setup      OpenBrowser    ${BASE_URI}/table3.html  ${BROWSER}  --headless      
 Suite Teardown   CloseBrowser
 #Test Timeout     60 seconds
 

--- a/test/acceptance/parallel/text.robot
+++ b/test/acceptance/parallel/text.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/text.html                 ${BROWSER}                  --HEADLESS
+Suite Setup                     OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}                  --HEADLESS
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 
@@ -67,7 +67,7 @@ Verify No Text Text Found Fail
     ...                         VerifyNoText                Lorem ipsum                 1s
 
 VerifyText Change Default Timeout
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyNoText                Delayed hidden text
     SetConfig                   DefaultTimeout              2s
     ClickText                   Show hidden
@@ -78,31 +78,31 @@ VerifyText Change Default Timeout
 
 VerifyTextCountOK
     [Tags]                      VerifyTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyTextCount             Counttextyjku               3                           timeout=1s
 
 VerifyTextCountIsZero
     [Tags]                      VerifyTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyTextCount             Foobarbaz                   0                           timeout=1s
 
 VerifyTextCountIsZeroWithExpected
     [Tags]                      VerifyTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${error}=                   Run Keyword And Expect Error
     ...                         QWebValueError: Page contained 0 texts instead of 4 after timeout
     ...                         VerifyTextCount             Foobarbaz                   4                           timeout=1s
 
 VerifyTextCountFail
     [Tags]                      VerifyTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${error}=                   Run Keyword And Expect Error
     ...                         QWebValueError: Page contained 3 texts instead of 4 after timeout
     ...                         VerifyTextCount             Counttextyjku               4                           timeout=1s
 
 VerifyTextCountDelay
     [Tags]                      VerifyTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyTextCount             Counttextyjku               3
     ClickText                   Counttextyjku               anchorcount
     VerifyTextCount             Counttextyjku               4                           timeout=5s
@@ -136,13 +136,13 @@ VerifyElementText Errors
 
 GetTextCountOK
     [Tags]                      GetTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${count}                    GetTextCount                Counttextyjku
     should be equal             ${count}                    ${3}
 
 GetTextCountisZero
     [Tags]                      GetTextCount
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     ${count}                    GetTextCount                FooBarBaz                   timeout=2
     should be equal             ${count}                    ${0}
 
@@ -238,17 +238,17 @@ IsText Xpath False
 
 IsText Timeout
     [Tags]                      IsText
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyNoText                Delayed hidden text
     ClickText                   Show hidden
     ${ret}=                     IsText                      Delayed hidden text         5s
     Should Be True              ${ret}
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyNoText                Delayed hidden text
 
 IsText Timeout False
     [Tags]                      IsText
-    Go To                       http://127.0.0.1:8000/text.html
+    Go To                       ${BASE_URI}/text.html
     VerifyNoText                Delayed hidden text
     ClickText                   Show hidden
     ${ret}=                     IsText                      Not there                   0.5s
@@ -325,14 +325,14 @@ Click Third Button where three with identical value
 
 Multiple Anchors Fail
     [tags]                      dev
-    GoTo                        http://127.0.0.1:8000/text.html
+    GoTo                        ${BASE_URI}/text.html
     VerifyNoText                The first Signup was clicked
     RunKeywordAndExpectError    QWebValueError*             ClickText                   Signup                      Anchor                      1s
     VerifyNoText                The first Signup was clicked
 
 Multiple Anchors Enabled
     [tags]                      dev
-    GoTo                        http://127.0.0.1:8000/text.html
+    GoTo                        ${BASE_URI}/text.html
     SetConfig                   MultipleAnchors             True
     VerifyNoText                The first Signup was clicked
     ClickText                   Signup                      Anchor

--- a/test/acceptance/parallel/text2.robot
+++ b/test/acceptance/parallel/text2.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/text.html                 ${BROWSER}                  --HEADLESS
+Suite Setup                     OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}                  --HEADLESS
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 

--- a/test/acceptance/parallel/text3.robot
+++ b/test/acceptance/parallel/text3.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/text.html                 ${BROWSER}                  --HEADLESS
+Suite Setup                     OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}                  --HEADLESS
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 

--- a/test/acceptance/parallel/text_multi.robot
+++ b/test/acceptance/parallel/text_multi.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation    Test for text in multiple elements
 Library          QWeb
-Suite Setup      OpenBrowser  http://127.0.0.1:8000/multielement_text.html  ${BROWSER}
+Suite Setup      OpenBrowser  ${BASE_URI}/multielement_text.html  ${BROWSER}
 ...              --headless
 Suite Teardown   CloseBrowser
 Test Timeout     60 seconds
@@ -31,7 +31,7 @@ Hover multi
     VerifyText      Hover Link1
 
 Numeric anchors as text
-    GoTo            http://127.0.0.1:8000/num_anchor.html
+    GoTo            ${BASE_URI}/num_anchor.html
     Run Keyword and Expect Error
     ...     QWebInstanceDoesNotExistError: Found 2 elements. Given anchor was 456
     ...     ClickText       LINK        456

--- a/test/acceptance/parallel/upload.robot
+++ b/test/acceptance/parallel/upload.robot
@@ -31,4 +31,4 @@ Upload with xpath
 
 *** Keywords ***
 SuiteStart
-     OpenBrowser    http://127.0.0.1:8000/upload.html    ${BROWSER}  --headless
+     OpenBrowser    ${BASE_URI}/upload.html    ${BROWSER}  --headless

--- a/test/acceptance/parallel/verifylinks.robot
+++ b/test/acceptance/parallel/verifylinks.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for handling of alerts
 Library           QWeb
-Suite Setup       OpenBrowser  http://127.0.0.1:8000/verifylinks.html  ${BROWSER}
+Suite Setup       OpenBrowser  ${BASE_URI}/verifylinks.html  ${BROWSER}
 ...               --headless
 Suite Teardown    CloseBrowser
 Test Timeout      60 seconds
@@ -17,4 +17,4 @@ VerifyLinks
 VerifyLinksError
     [Tags]          VerifyLinks      Error    jailed
     Run Keyword And Expect Error    QWebException: Found 2 broken link(s):*
-    ...             VerifyLinks     http://127.0.0.1:8000/verifybrokenlinks.html    timeout=5
+    ...             VerifyLinks     ${BASE_URI}/verifybrokenlinks.html    timeout=5

--- a/test/acceptance/parallel/window.robot
+++ b/test/acceptance/parallel/window.robot
@@ -14,7 +14,7 @@ Go To
     [Tags]                      Window    GoTo
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Should Be Equal             ${driver.current_url}       about:blank
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     Should Be Equal             ${driver.title}             Window Acceptance Tests
 
 Open Window
@@ -28,7 +28,7 @@ Open Window Changed To New Window
     [Tags]                      Window    OpenWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     OpenWindow
     Should Be Equal             ${driver.current_url}       about:blank
 
@@ -45,7 +45,7 @@ Switch Window
     [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     OpenWindow
     Length Should Be            ${driver.window_handles}    2
     Should Be Equal             ${driver.current_url}       about:blank
@@ -56,7 +56,7 @@ Switch window, check context
     [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     OpenWindow
     Length Should Be            ${driver.window_handles}    2
     Should Be Equal             ${driver.current_url}       about:blank
@@ -100,7 +100,7 @@ Switch window, multiple closings, check context
     [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     OpenWindow
     Length Should Be            ${driver.window_handles}    2
     Should Be Equal             ${driver.current_url}       about:blank
@@ -137,14 +137,14 @@ Close window, no tabs open
     [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     Close window
 
 Switch window, open multiple, close index
     [Tags]                      Window    SwitchWindow
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     OpenWindow
     Length Should Be            ${driver.window_handles}    2
     ${url}=                     GetUrl
@@ -152,7 +152,7 @@ Switch window, open multiple, close index
     Should Be Equal             ${url}                      about:blank
     OpenWindow
     Length Should Be            ${driver.window_handles}    3
-    GoTO                        http://127.0.0.1:8000/window.html
+    GoTO                        ${BASE_URI}/window.html
     Should Be Equal             ${driver.title}             Window Acceptance Tests
     OpenWindow
     Length Should Be            ${driver.window_handles}    4
@@ -166,7 +166,7 @@ Switch window, open multiple, close index
 Title and url
     [Tags]                      Window    Title    Url
     [Documentation]             Tests for -title and -url keywords
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     ${url}=                     GetUrl
     Should Contain              ${url}                      http://
     Should Contain              ${url}                      window.html
@@ -208,16 +208,16 @@ Close Other Windows
     [Tags]                      Window
     [Documentation]             Close other windows
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     VerifyText                  Liirum
     Close Others
     OpenWindow
-    GoTo                        http://127.0.0.1:8000/text.html
+    GoTo                        ${BASE_URI}/text.html
     VerifyText                  HoverDropdown
     SwitchWindow                1
     VerifyText                  Liirum
     OpenWindow
-    GoTo                        http://127.0.0.1:8000/table.html
+    GoTo                        ${BASE_URI}/table.html
     VerifyText                  Table acceptance
     CloseOthers
     Length Should Be            ${driver.window_handles}    1
@@ -226,7 +226,7 @@ Close Other Windows
 Self Closing PopUp
     [Tags]                      Window
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
-    GoTo                        http://127.0.0.1:8000/window.html
+    GoTo                        ${BASE_URI}/window.html
     Close Others
     ClickText                   Open
     SwitchWindow                NEW
@@ -245,7 +245,7 @@ SwitchWindow 0
 Open New Tab Link Page
     ${driver}=                  Evaluate                    sys.modules["QWeb.internal.browser"].get_current_browser()            modules=sys
     Length Should Be            ${driver.window_handles}    1
-    GoTo                        http://127.0.0.1:8000/newtablink.html
+    GoTo                        ${BASE_URI}/newtablink.html
     # Open one extra window
     ClickText                   Open new window
     Sleep                       3                           # Firefox needs some time

--- a/test/acceptance/safari_smoke.robot
+++ b/test/acceptance/safari_smoke.robot
@@ -10,7 +10,7 @@ ${ON_HTTP_SERVER}=    ${FALSE}
 Open Safari
     [Tags]          PROBLEM_IN_WINDOWS    PROBLEM_IN_LINUX    PROBLEM_IN_CHROME    PROBLEM_IN_EDGE    PROBLEM_IN_FIREFOX
     OpenBrowser    about:blank    safari
-    GoTo    127.0.0.1:8000/text.html    timeout=5
+    GoTo    ${BASE_URI}/text.html    timeout=5
     CloseAllBrowsers
 
 *** Keywords ***

--- a/test/acceptance/safari_smoke.robot
+++ b/test/acceptance/safari_smoke.robot
@@ -6,5 +6,5 @@ Test Timeout      30 seconds
 Open Safari
     [Tags]          PROBLEM_IN_WINDOWS    PROBLEM_IN_LINUX    PROBLEM_IN_CHROME    PROBLEM_IN_EDGE    PROBLEM_IN_FIREFOX
     OpenBrowser    about:blank    safari
-    GoTo    http://127.0.0.1:8000/text.html    timeout=5
+    GoTo    ${BASE_URI}/text.html    timeout=5
     CloseAllBrowsers

--- a/test/acceptance/safari_smoke.robot
+++ b/test/acceptance/safari_smoke.robot
@@ -1,10 +1,23 @@
 *** Settings ***
 Library           QWeb
 Test Timeout      30 seconds
+Suite Setup     Check Http Server
+
+*** Variables ***
+${ON_HTTP_SERVER}=    ${FALSE}
 
 *** Test Cases ***
 Open Safari
     [Tags]          PROBLEM_IN_WINDOWS    PROBLEM_IN_LINUX    PROBLEM_IN_CHROME    PROBLEM_IN_EDGE    PROBLEM_IN_FIREFOX
     OpenBrowser    about:blank    safari
-    GoTo    ${BASE_URI}/text.html    timeout=5
+    GoTo    127.0.0.1:8000/text.html    timeout=5
     CloseAllBrowsers
+
+*** Keywords ***
+Check Http Server
+    IF    $ON_HTTP_SERVER
+        ${BASE_URI}=    Set Variable    http://127.0.0.1:8000
+    ELSE
+        ${BASE_URI}=    Set Variable    file:///${CURDIR}/../resources
+    END
+    Set Global Variable    ${BASE_URI}

--- a/test/acceptance/serial/dragdrop.robot
+++ b/test/acceptance/serial/dragdrop.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Tests for Drag and Drop keyword
 Library           QWeb
-Suite Setup       OpenBrowser    http://127.0.0.1:8000/drag.html    ${BROWSER}
+Suite Setup       OpenBrowser    ${BASE_URI}/drag.html    ${BROWSER}
 Suite Teardown    CloseBrowser
 Test Setup        SetConfig       WindowSize    1920x1080
 Test Timeout      60 seconds

--- a/test/acceptance/serial/icon.robot
+++ b/test/acceptance/serial/icon.robot
@@ -2,7 +2,7 @@
 Documentation       Tests for icon keywords
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}
-Test Setup          GoTo    http://127.0.0.1:8000/items.html
+Test Setup          GoTo    ${BASE_URI}/items.html
 Suite Teardown      CloseBrowser
 Library             Dialogs
 Test Timeout        60 seconds
@@ -113,7 +113,7 @@ IsIcon False
 WriteText
     [Tags]                  jailed	PROBLEM_IN_FIREFOX      RESOLUTION_DEPENDENCY    PROBLEM_IN_MACOS
     CloseAllBrowsers
-    OpenBrowser             http://127.0.0.1:8000/input.html    chrome
+    OpenBrowser             ${BASE_URI}/input.html    chrome
     ClickIcon               leftright
     WriteText               FooBar
     VerifyInputValue        odjdq               Foobar     selector=id

--- a/test/acceptance/serial/input_windowed.robot
+++ b/test/acceptance/serial/input_windowed.robot
@@ -2,7 +2,7 @@
 Documentation    Tests for input keywords
 Library          QWeb
 Library          OperatingSystem
-Suite Setup      OpenBrowser    http://127.0.0.1:8000/input.html    ${BROWSER}
+Suite Setup      OpenBrowser    ${BASE_URI}/input.html    ${BROWSER}
 Suite Teardown   CloseAllBrowsers
 Test Timeout     60 seconds
 
@@ -20,7 +20,7 @@ PressKey Paste
 
 Global hotkeys
     [Tags]    PressKey    RESOLUTION_DEPENDENCY
-    GoTo           http://127.0.0.1:8000/text.html
+    GoTo           ${BASE_URI}/text.html
     Set Config            WindowSize    1920x1080
     ${scroll_text}=       GetText       Current scroll
     Should Be Equal As Strings    ${scroll_text}                     Current scroll = scroll the window

--- a/test/acceptance/serial/screenshot.robot
+++ b/test/acceptance/serial/screenshot.robot
@@ -2,7 +2,7 @@
 Documentation       Test for screenshot functionality
 Library             QWeb
 Library             OperatingSystem
-Suite Setup         OpenBrowser    http://127.0.0.1:8000/text.html    ${BROWSER}  #--headless
+Suite Setup         OpenBrowser    ${BASE_URI}/text.html    ${BROWSER}  #--headless
 Suite Teardown      CloseBrowser
 Test Timeout        60 seconds
 
@@ -63,16 +63,16 @@ Test VerifyApp
     Directory Should exist         ${OUTPUT_DIR}/verifyapp
     File Should Exist              ${OUTPUT_DIR}/verifyapp/Test_VerifyApp_verifyapp_ref.png
     VerifyApp                      verifyapp
-    Go To                          http://127.0.0.1:8000/dropdown.html
+    Go To                          ${BASE_URI}/dropdown.html
     Run keyword and expect error   *Images differ    VerifyApp      verifyapp
     Remove File                    ${OUTPUT_DIR}/verifyapp/Test_VerifyApp_verifyapp_ref.png
 
 Test VerifyApp Accuracy
     [Tags]         RESOLUTION_DEPENDENCY
-    Go To          http://127.0.0.1:8000/text.html
+    Go To          ${BASE_URI}/text.html
     SetConfig      VerifyAppAccuracy        0.0001
     VerifyApp      acctest
-    Go To          http://127.0.0.1:8000/dropdown.html
+    Go To          ${BASE_URI}/dropdown.html
     VerifyApp      acctest
     SetConfig      VerifyAppAccuracy        0.9999
     Run keyword and expect error            *Images differ    VerifyApp      acctest

--- a/test/acceptance/serial/shadow_dom.robot
+++ b/test/acceptance/serial/shadow_dom.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 http://127.0.0.1:8000/shadow_dom.html           ${BROWSER}    #--headless
+Suite Setup                     OpenBrowser                 ${BASE_URI}/shadow_dom.html           ${BROWSER}    #--headless
 Suite Teardown                  Shadow Teardown
 Test Timeout                    60 seconds
 
@@ -43,7 +43,7 @@ Basic interactions with Shadow DOM
 
 Shadow DOM with attributes
     [Setup]                     SetConfig                   ShadowDOM                   True
-    GoTo                        http://127.0.0.1:8000/shadow_dom.html
+    GoTo                        ${BASE_URI}/shadow_dom.html
     # using attribute values
     VerifyItem                  myButton                    # id
     VerifyItem                  Click this                  # tooltip
@@ -61,7 +61,7 @@ Shadow DOM with attributes
 
 Shadow DOM on, normal DOM elements
     [Setup]                     SetConfig                   ShadowDOM                   True
-    GoTo                        http://127.0.0.1:8000/shadow_dom.html
+    GoTo                        ${BASE_URI}/shadow_dom.html
     # verifying items that are in normal dom
     VerifyText                  In both DOM
     VerifyText                  Level 1
@@ -77,7 +77,7 @@ Shadow DOM on, normal DOM elements
 
 VerifyAll & VerifyAny with shadow DOM
     [Setup]                     SetConfig                   ShadowDOM                   False
-    GoTo                        http://127.0.0.1:8000/shadow_dom.html
+    GoTo                        ${BASE_URI}/shadow_dom.html
     # verify using normal dom only
     ${error}=                   Run Keyword and Expect Error                            *
     ...                         VerifyAll                   In both DOM,Input2          timeout=2
@@ -90,7 +90,7 @@ VerifyAll & VerifyAny with shadow DOM
 
 Input keywords with shadow DOM
     [Setup]                     SetConfig                   ShadowDOM                   False
-    GoTo                        http://127.0.0.1:8000/shadow_dom.html
+    GoTo                        ${BASE_URI}/shadow_dom.html
     # verify inputs using normal dom only
     TypeText                    username                    John Doe                    # in normal/light dom
     ${error}=                   Run Keyword and Expect Error                            *
@@ -120,7 +120,7 @@ Input keywords with shadow DOM
 
 Text Counts with shadow DOM
     [Setup]                     SetConfig                   ShadowDOM                   False
-    GoTo                        http://127.0.0.1:8000/shadow_dom.html
+    GoTo                        ${BASE_URI}/shadow_dom.html
     # verify count using normal dom only
     VerifyTextCount             In both DOM                 1
 

--- a/test/acceptance/serial/swipe.robot
+++ b/test/acceptance/serial/swipe.robot
@@ -2,7 +2,7 @@
 Documentation       Test for ClickItem keyword
 Library             QWeb
 Suite Setup         OpenBrowser    about:blank    ${BROWSER}
-Test Setup          GoTo    http://127.0.0.1:8000/swipe.html
+Test Setup          GoTo    ${BASE_URI}/swipe.html
 Suite Teardown      CloseBrowser
 Test Timeout        60 seconds
 
@@ -27,7 +27,7 @@ ScrollTo
     [Tags]            ScrollTo  RESOLUTION_DEPENDENCY
     [Timeout]         20 seconds
     SetConfig         WindowSize   1600x900
-    GoTo              http://127.0.0.1:8000/text.html
+    GoTo              ${BASE_URI}/text.html
     ScrollTo          Current scroll
     # Verify that we have scrolled (default text "scroll the window" has vanished)
     VerifyNoText      scroll the window


### PR DESCRIPTION
When running tests outside of gh actions or local duty, it's easier to use the http files directly from the file system instead of an http server.

Added `__init__.robot` fle into __tests/acceptance__ directory which checks a global variable `${ON_HTTP_SERVER}` (defaults to `False`) which tells if the tests will be run on http server and then sets a base URI accordingly for the test cases