### PR TITLE
Tko clickable slot text

### DIFF
--- a/test/acceptance/__init__.robot
+++ b/test/acceptance/__init__.robot
@@ -1,12 +1,12 @@
 *** Settings ***
-Suite Setup    Check Http Server
+Suite Setup       CheckHttpServer
 
 *** Variables ***
 ${ON_HTTP_SERVER}=    ${FALSE}
 
 *** Keywords ***
 Check Http Server
-    IF    $ON_HTTP_SERVER
+    IF    ${ON_HTTP_SERVER}
         ${BASE_URI}=    Set Variable    http://127.0.0.1:8000
     ELSE
         ${BASE_URI}=    Set Variable    file:///${CURDIR}/../resources

--- a/test/acceptance/parallel/upload.robot
+++ b/test/acceptance/parallel/upload.robot
@@ -2,7 +2,7 @@
 Documentation     Tests for UploadFile keyword
 Library           QWeb
 Suite Setup       SuiteStart
-Suite Teardown    CloseBrowser
+Suite Teardown    SuiteEnd
 Test Timeout      60 seconds
 
 *** Variables ***
@@ -32,3 +32,7 @@ Upload with xpath
 *** Keywords ***
 SuiteStart
      OpenBrowser    ${BASE_URI}/upload.html    ${BROWSER}  --headless
+
+SuiteEnd
+    ResetConfig    DefaultTimeout
+    CloseAllBrowsers

--- a/test/acceptance/serial/download.robot
+++ b/test/acceptance/serial/download.robot
@@ -24,6 +24,7 @@ Verify File Download Slow Bandwidth
 
 Verify File Download Fails If Multiple Files Found
     [Tags]    PROBLEM_IN_SAFARI
+    RefreshPage
     VerifyText      Download small csv file
     ExpectFileDownload
     Two Files Are Downloaded Without ExpectFileDownload Keyword

--- a/test/acceptance/serial/download.robot
+++ b/test/acceptance/serial/download.robot
@@ -24,7 +24,6 @@ Verify File Download Slow Bandwidth
 
 Verify File Download Fails If Multiple Files Found
     [Tags]    PROBLEM_IN_SAFARI
-    RefreshPage
     VerifyText      Download small csv file
     ExpectFileDownload
     Two Files Are Downloaded Without ExpectFileDownload Keyword

--- a/test/acceptance/serial/download.robot
+++ b/test/acceptance/serial/download.robot
@@ -23,8 +23,7 @@ Verify File Download Slow Bandwidth
     FileShouldExist  ${downloaded}
 
 Verify File Download Fails If Multiple Files Found
-    [Tags]    PROBLEM_IN_SAFARI    jailed
-    # failure is only happening in CRT+chrome, disabling this temporarily to make QAutomation release happen
+    [Tags]    PROBLEM_IN_SAFARI
     VerifyText      Download small csv file
     ExpectFileDownload
     Two Files Are Downloaded Without ExpectFileDownload Keyword

--- a/test/acceptance/serial/shadow_dom.robot
+++ b/test/acceptance/serial/shadow_dom.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 ${BASE_URI}/shadow_dom.html           ${BROWSER}    #--headless
+Suite Setup                     OpenBrowser                 ${BASE_URI}/shadow_dom.html           ${BROWSER}  #--headless
 Suite Teardown                  Shadow Teardown
 Test Timeout                    60 seconds
 
@@ -164,11 +164,11 @@ Chrome shadow DOM
 
     SetConfig                   ShadowDOM                   False
     GoTo                        chrome://downloads
-    ${error}=                   Run Keyword and Expect Error                            *                           VerifyText           Downloads    timeout=2
+    ${error}=                   Run Keyword and Expect Error                            *                           VerifyText           Files you download appear here    timeout=2
 
     SetConfig                   ShadowDOM                   True
-    VerifyText                  Downloads                   timeout=3
-    TypeText                    Search downloads            Test
+    VerifyText                  Files you download appear here                   timeout=3
+    TypeText                    Search download            Test
     LogScreenshot
 
 


### PR DESCRIPTION
Fix for **ClickText** in unconventional cases where text is directly in `<slot>` element, not it's parent or child. Slots do not have offsets etc. so by default they are considered invisible by our visibility check.
 
+ ...also Mikko's branch fixing tests was merged here