### PR TITLE
fix: incorrectly forwarding kwargs to get_checkbox_by_locator()

### DIFF
--- a/QWeb/internal/checkbox.py
+++ b/QWeb/internal/checkbox.py
@@ -119,7 +119,7 @@ def get_checkbox_elements_from_all_documents(
             locator, anchor=anchor, index=index, **kwargs
         )
         if not checkbox_element:
-            checkbox_element, locator_element = get_checkbox_by_locator(locator, anchor, **kwargs)
+            checkbox_element, locator_element = get_checkbox_by_locator(locator, anchor)
     if checkbox_element:
         return checkbox_element, locator_element
     raise QWebElementNotFoundError("No matching element found")


### PR DESCRIPTION
Not sure why this wasn't spotted, but kwargs got incorrectly forwared to get_checkbox_by_locator()...this will cause an error in specific situation when using ClickCheckbox