### PR TITLE
Tko fix all frames element type

### DIFF
--- a/QWeb/internal/text.py
+++ b/QWeb/internal/text.py
@@ -408,6 +408,8 @@ def _get_item_by_css(text: str, **kwargs) -> Optional[list[WebElement]]:
         "a, span, img, li, h1, h2, h3, h4, h5, h6, div, svg, p, button, input"
         ':not([type="text"]):not([type="password"]):not([type="email"])'
     )
+    # get_elements_by_attributes already handles going through frames
+    kwargs["continue_search"] = False
     full, partial = element.get_elements_by_attributes(css, text, **kwargs)
     web_elements = element.get_visible_elements_from_elements(full + partial, **kwargs)
     if web_elements:

--- a/QWeb/keywords/element.py
+++ b/QWeb/keywords/element.py
@@ -623,6 +623,9 @@ def get_attribute(
     ----------------
     \`VerifyAttribute\`, \`VerifyElement\`
     """
+    # remove all_frames from kwargs if given. It's not supported by
+    # GetAttribute, but would give error later
+    kwargs.pop("all_frames", None)
     webelement = get_webelement(locator, anchor, element_type, timeout, all_frames=False, **kwargs)
 
     if not webelement:

--- a/test/acceptance/parallel/frame.robot
+++ b/test/acceptance/parallel/frame.robot
@@ -157,13 +157,13 @@ Upload with xpath
     ShouldBeEqual               ${value}                    C:\fakepath\test2.txt
 
 GetTextCount and VerifyTextCount from multiple frames
-    [Tags]                      Frame    Upload
+    [Tags]                      Frame
     ${count}=                   GetTextCount    text
     Should Be Equal As Numbers  ${count}        15
     VerifyTextCount             Text            7
     
 GetWebelement from multiple frames
-    [Tags]                      Frame    Upload
+    [Tags]                      Frame
     ${elems}=                   GetWebElement    //button    all_frames=False
     ${count_one_frame}=         Evaluate         len($elems)
     ${elems}=                   GetWebElement    //button
@@ -171,3 +171,21 @@ GetWebelement from multiple frames
     Should Be Equal As Numbers  ${count_one_frame}         1
     Should Be Equal As Numbers  ${count_all_frames}        7
 
+
+GetWebelement & GetAttribute from multiple frames with element type
+    [Tags]                      Frame    Get
+    # Without all_frames
+    ${elem1}=                    GetWebElement    Blue     element_type=item    tag=input
+    ${attr1}=                    GetAttribute     Blue     id    element_type=item    tag=input
+    ${elem2}=                    GetWebElement    Button1  element_type=text
+    ${attr2}=                    GetAttribute     skimClick disable button  id    element_type=text
+    ShouldBeEqual                ${attr1}         ch_1_1
+    ShouldBeEqual                ${attr2}         skimclick
+    
+    # With all_frames, note that all_frames is not even supported in GetAttribute
+    ${elem1}=                    GetWebElement    Blue     element_type=item    tag=input    all_frames=True
+    ${attr1}=                    GetAttribute     Blue     id    element_type=item    tag=input      all_frames=True
+    ${elem2}=                    GetWebElement    Button1  element_type=text    all_frames=True
+    ${attr2}=                    GetAttribute     skimClick disable button  id    element_type=text  all_frames=True
+    ShouldBeEqual                ${attr1}         ch_1_1
+    ShouldBeEqual                ${attr2}         skimclick


### PR DESCRIPTION
- Fix issue with **GetWebelement** when **element_type** is used (ValueError: too many values to unpack (expected 2)
- Check for unsupported kwarg all_frames in GetAttribute to avoid errors later
- Add test to the above mentioned issues