### PR TITLE
fix: fix issue of inputs not being found by attribute (=javascript) search

### DIFF
--- a/QWeb/internal/browser/chrome.py
+++ b/QWeb/internal/browser/chrome.py
@@ -158,6 +158,6 @@ def cache_browser_session(driver: WebDriver) -> None:
     )
     if browser_reuse_enabled:
         dbg_address = driver.capabilities["goog:chromeOptions"]["debuggerAddress"]
-        write_browser_session_argsfile(dbg_address, driver.command_executor._url)  # type: ignore # pylint: disable=protected-access
+        write_browser_session_argsfile(dbg_address, driver.service.service_url)  # type: ignore # pylint: disable=protected-access
         BuiltIn().set_global_variable("${BROWSER_EXECUTOR_URL}", None)
         BuiltIn().set_global_variable("${BROWSER_DEBUGGER_ADDRESS}", None)

--- a/QWeb/internal/browser/chrome.py
+++ b/QWeb/internal/browser/chrome.py
@@ -158,6 +158,6 @@ def cache_browser_session(driver: WebDriver) -> None:
     )
     if browser_reuse_enabled:
         dbg_address = driver.capabilities["goog:chromeOptions"]["debuggerAddress"]
-        write_browser_session_argsfile(dbg_address, driver.service.service_url)  # type: ignore # pylint: disable=protected-access
+        write_browser_session_argsfile(dbg_address, driver.service.service_url)  # type: ignore
         BuiltIn().set_global_variable("${BROWSER_EXECUTOR_URL}", None)
         BuiltIn().set_global_variable("${BROWSER_DEBUGGER_ADDRESS}", None)

--- a/QWeb/internal/element.py
+++ b/QWeb/internal/element.py
@@ -659,9 +659,9 @@ def get_elements_by_attributes(
         # there have been few cases where css search doesn't work
         if len(matches.get("full", [])) == 0 and len(matches.get("partial", [])) == 0:
             try:
-                css = css if xpath_search else f"//{css}"
+                xpath = css if xpath_search else f"//{css}"
                 driver = browser.get_current_browser()
-                elements = driver.find_elements(By.XPATH, css)
+                elements = driver.find_elements(By.XPATH, xpath)
 
                 matches = javascript.get_by_attributes(
                     elements,

--- a/QWeb/internal/input_.py
+++ b/QWeb/internal/input_.py
@@ -186,7 +186,6 @@ def get_input_element_by_css_selector(
         full_matches, partial_matches = get_input_elements_by_css(locator, **kwargs)
         # backup search via xpath. This is needed due to javascript search not reaching
         # all inputs under pseudo elements
-        # TODO: Finalize
         if not full_matches and not partial_matches:
             css = CONFIG["AllInputElements"]
             full_matches, partial_matches = element.get_elements_by_attributes(css, locator)

--- a/QWeb/internal/input_.py
+++ b/QWeb/internal/input_.py
@@ -184,6 +184,12 @@ def get_input_element_by_css_selector(
             logger.debug("locator was text")
     if "qweb_old" not in kwargs:
         full_matches, partial_matches = get_input_elements_by_css(locator, **kwargs)
+        # backup search via xpath. This is needed due to javascript search not reaching
+        # all inputs under pseudo elements
+        # TODO: Finalize
+        if not full_matches and not partial_matches:
+            css = CONFIG["AllInputElements"]
+            full_matches, partial_matches = element.get_elements_by_attributes(css, locator)
 
         if full_matches:
             full_matches = text.filter_by_modal_ancestor(full_matches)

--- a/QWeb/internal/input_.py
+++ b/QWeb/internal/input_.py
@@ -187,8 +187,8 @@ def get_input_element_by_css_selector(
         # backup search via xpath. This is needed due to javascript search not reaching
         # all inputs under pseudo elements
         if not full_matches and not partial_matches:
-            css = CONFIG["AllInputElements"]
-            full_matches, partial_matches = element.get_elements_by_attributes(css, locator)
+            xpath = CONFIG["AllInputElements"]
+            full_matches, partial_matches = element.get_elements_by_attributes(xpath, locator)
 
         if full_matches:
             full_matches = text.filter_by_modal_ancestor(full_matches)

--- a/QWeb/internal/screenshot.py
+++ b/QWeb/internal/screenshot.py
@@ -313,7 +313,7 @@ def chromium_full_screenshot(driver: WebDriver, filepath: str) -> str:
         resource = f"/session/{driver.session_id}/chromium/send_command_and_get_result"
 
         # pylint:disable=W0212
-        url = driver.command_executor._url + resource
+        url = driver.service.service_url + resource
         body = json.dumps({"cmd": cmd, "params": params})
         response = driver.command_executor._request("POST", url, body)
         return response.get("value")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyAutoGUI>=0.9.53
 Pillow>=10.3.0,<11
 robotframework>=4.1.3,<8
 robotframework-debuglibrary==2.5.0
-selenium>=4.16.0,<5
+selenium>=4.16.0,<4.26.0
 ply
 pynput==1.7.7
 setuptools>=70.0.0

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
                       'requests>=2.32.2',
                       "robotframework>=4.1.3,<8",
                       "robotframework-debuglibrary==2.5.0",
-                      "selenium>=4.16.0,<5",
+                      "selenium>=4.16.0,<4.26.0",
                       "Pillow>=10.3.0,<11",
                       "scipy>=1.7.3",
                       "scikit-image==0.21;python_version=='3.8'",

--- a/test/acceptance/serial/browser_windowed.robot
+++ b/test/acceptance/serial/browser_windowed.robot
@@ -52,7 +52,7 @@ Open Browser with invalid experimental args string
     ...     prefs=Foobar, "anotherone":"false"
 
 Open Browser with options and verify
-    [tags]          exp             PROBLEM_IN_SAFARI    PROBLEM_IN_FIREFOX    PROBLEM_IN_EDGE
+    [tags]          exp             PROBLEM_IN_SAFARI    PROBLEM_IN_FIREFOX    PROBLEM_IN_EDGE    PROBLEM_IN_WINDOWS
     [Documentation]                 Run this only in Chrome
     [Setup]    No Operation
     [Teardown]                      SetConfig            ShadowDOM             Off


### PR DESCRIPTION
…in some salesforce views

...as they are under pseudoelement which cannot be parsed via javascript. We will do xpath search as a backup if nothign is found with "normal" means