### PR TITLE
Tko rfw 5 as minimum

### DIFF
--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -22,4 +22,5 @@ jobs:
       os: '["ubuntu-latest"]'
       browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.9", "3.12"]'
-      rfw-4x-python: "3.9"
+      minimum-rfw-version: "5.1.1"
+      minimum-rfw-python: "3.9"

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -22,5 +22,5 @@ jobs:
       os: '["ubuntu-latest"]'
       browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.9", "3.12"]'
-      minimum-rfw-version: "5.1.1"
+      minimum-rfw-version: "5.0.1"
       minimum-rfw-python: "3.9"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -22,6 +22,6 @@ jobs:
       os: '["macos-latest"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
-      minimum-rfw-version: "5.1.1"
+      minimum-rfw-version: "5.0.1"
       minimum-rfw-python: "3.10"
       rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -22,5 +22,6 @@ jobs:
       os: '["macos-latest"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
-      rfw-4x-python: "3.10"
+      minimum-rfw-version: "5.1.1"
+      minimum-rfw-python: "3.10"
       rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -18,10 +18,14 @@ on:
         description: 'Stringified JSON object listing target Python versions'
         required: true
         type: string
-      rfw-4x-python:
-        description: Python version which will be used with RFW 4.x
+      minimum-rfw-python:
+        description: Python version which will be using the minimum required rfw version
         required: true
         type: string
+      minimum-rfw-version:
+          description: Minimum RFW dependency version
+          required: true
+          type: string
       rfw-exclude-tags:
         description: Tag exclusions which will be added to RFW execution. For example  "-e FLASK"
         required: false
@@ -71,10 +75,10 @@ jobs:
         xauth generate $DISPLAY .
         popd
 
-    - name: Install RFW 4.x
-      if: matrix.python-version == inputs.rfw-4x-python
+    - name: Install RFW ${{ inputs.minimum-rfw-version }}
+      if: matrix.python-version == inputs.minimum-rfw-python
       run: |
-        python -m pip install robotframework==4.1.3
+        python -m pip install robotframework==${{ inputs.minimum-rfw-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -22,6 +22,7 @@ jobs:
       os: '["windows-latest"]'
       browser: '["chrome", "edge", "firefox"]'
       python-version: '["3.11", "3.12"]'
-      rfw-4x-python: "3.11"
+      minimum-rfw-version: "5.1.1"
+      minimum-rfw-python: "3.11"
       rfw-exclude-tags: "-e FLASK"
       

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -22,7 +22,7 @@ jobs:
       os: '["windows-latest"]'
       browser: '["chrome", "edge", "firefox"]'
       python-version: '["3.11", "3.12"]'
-      minimum-rfw-version: "5.1.1"
+      minimum-rfw-version: "5.0.1"
       minimum-rfw-python: "3.11"
       rfw-exclude-tags: "-e FLASK"
       

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [examples](#examples).
 
 ---
 ## Requirements
-Python **3.9-3.12** and Robot Framework 4.1.3 or above.
+Python **3.9-3.12** and Robot Framework 5.1.1 or above.
 
 (Note that support on Macs with Apple based silicon (M1) requires MacOS version 12/Monterey or above or [custom installation](https://github.com/qentinelqi/qweb/blob/master/docs/qweb_mac_m1_installation.md).)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [examples](#examples).
 
 ---
 ## Requirements
-Python **3.9-3.12** and Robot Framework 5.1.1 or above.
+Python **3.9-3.12** and Robot Framework 5.0.1 or above.
 
 (Note that support on Macs with Apple based silicon (M1) requires MacOS version 12/Monterey or above or [custom installation](https://github.com/qentinelqi/qweb/blob/master/docs/qweb_mac_m1_installation.md).)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyScreeze==0.1.28
 PyAutoGUI>=0.9.53
 Pillow>=10.3.0,<11
-robotframework>=5.1.1,<8
+robotframework>=5.0.1,<8
 robotframework-debuglibrary==2.5.0
 selenium>=4.16.0,<4.26.0
 ply

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyScreeze==0.1.28
 PyAutoGUI>=0.9.53
 Pillow>=10.3.0,<11
-robotframework>=4.1.3,<8
+robotframework>=5.1.1,<8
 robotframework-debuglibrary==2.5.0
 selenium>=4.16.0,<4.26.0
 ply

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                       "pyautogui>=0.9.53",
                       "pynput>=1.7.7",
                       'requests>=2.32.2',
-                      "robotframework>=5.1.1,<8",
+                      "robotframework>=5.0.1,<8",
                       "robotframework-debuglibrary==2.5.0",
                       "selenium>=4.16.0,<4.26.0",
                       "Pillow>=10.3.0,<11",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                       "pyautogui>=0.9.53",
                       "pynput>=1.7.7",
                       'requests>=2.32.2',
-                      "robotframework>=4.1.3,<8",
+                      "robotframework>=5.1.1,<8",
                       "robotframework-debuglibrary==2.5.0",
                       "selenium>=4.16.0,<4.26.0",
                       "Pillow>=10.3.0,<11",

--- a/test/acceptance/parallel/window.robot
+++ b/test/acceptance/parallel/window.robot
@@ -250,7 +250,7 @@ Open New Tab Link Page
     # Open one extra window
     ClickText                   Open new window
     Sleep                       3                           # Firefox needs some time
-    [Return]                    ${driver}
+    RETURN                      ${driver}
 
 Open Two Windows
     ClickText                   Open new window


### PR DESCRIPTION
We'll make rfw 5.1.1 the minimum (tested) version instead of 4.x

changed:
- setup.py and requirements.txt
- pipeline
- tests using [RETURN]