### PR TITLE
fix: Handle full match in table keywords in a different way, which su…

### DIFF
--- a/QWeb/internal/browser/__init__.py
+++ b/QWeb/internal/browser/__init__.py
@@ -124,7 +124,7 @@ def cache_browser(driver: WebDriver) -> None:
     # pylint: disable=global-statement
     global _current_browser
     # pylint: disable=global-statement, global-variable-not-assigned
-    global _open_browsers
+    global _open_browsers  # noqa: F824
     _current_browser = driver
     _open_browsers.append(driver)
 
@@ -135,7 +135,7 @@ def remove_from_browser_cache(driver: WebDriver) -> None:
     # pylint: disable=global-statement
     global _current_browser
     # pylint: disable=global-statement, global-variable-not-assigned
-    global _open_browsers
+    global _open_browsers  # noqa: F824
     _open_browsers.remove(driver)
     # there's at least one browser open, move to latest
     _current_browser = _open_browsers[-1] if _open_browsers else None

--- a/QWeb/internal/file.py
+++ b/QWeb/internal/file.py
@@ -41,9 +41,9 @@ class File:
             reader = PdfReader(filepath)
             for page in reader.pages:
                 all_text += page.extract_text()
-                if all_text != "":
-                    return File(all_text, filepath)
-                raise QWebValueMismatchError("Text not found. Seems that the pdf is empty.")
+            if all_text != "":
+                return File(all_text, filepath)
+            raise QWebValueMismatchError("Text not found. Seems that the pdf is empty.")
         except PdfStreamError as e:
             raise QWebFileNotFoundError(f"File found, but it's not valid pdf-file: {e}") from e
 

--- a/QWeb/internal/table.py
+++ b/QWeb/internal/table.py
@@ -395,7 +395,9 @@ class Table:
         return javascript.execute_javascript(js, self.table)
 
     def get_full_match_column_index(self, locator: str) -> int:
-        """Get the index of the column based on the locator text. Full match"""
+        """Get the index of the column based on the locator text. Full match
+            is used to find the column header. Returned Index starts from 1.
+        """
         columns = self.get_columns()
         column_texts = self.get_column_header_texts(columns)
         try:
@@ -406,7 +408,7 @@ class Table:
         return index
 
     def get_column_header_texts(self, columns: List[WebElement]) -> List[str]:
-        # prefer using title, then aria-label, then text
+        # prefer using aria-label, then title, then text
         column_texts = [
             c.get_attribute("aria-label") or c.get_attribute("title") or c.text for c in columns
         ]

--- a/QWeb/internal/table.py
+++ b/QWeb/internal/table.py
@@ -176,7 +176,7 @@ class Table:
         else:
             row, _ = self._convert_coordinates(locator[0])
         if locator[1].startswith("c?"):
-            # try with old one if no full matches or if partial match used
+            # try with old one if partial match used
             if partial_match:
                 column = self.get_cell_by_locator(locator[1][2:], **kwargs)
             else:
@@ -401,8 +401,8 @@ class Table:
         try:
             index = column_texts.index(locator)
             index = index + 1
-        except ValueError:
-            raise QWebValueError(f"Matching column not found for locator {locator}.")
+        except ValueError as e:
+            raise QWebValueError(f"Matching column not found for locator {locator}.") from e
         return index
 
     def get_column_header_texts(self, columns: List[WebElement]) -> List[str]:

--- a/QWeb/keywords/table.py
+++ b/QWeb/keywords/table.py
@@ -513,7 +513,7 @@ def get_col_header(index: Optional[int] = None) -> Union[str, List[str]]:
     table = Table.ACTIVE_TABLE.update_table()
     columns = table.get_columns()
 
-    column_texts = _get_column_header_texts(columns)
+    column_texts = table.get_column_header_texts(columns)
 
     if not index:
         return column_texts
@@ -586,14 +586,14 @@ def verify_col_header(expected: str, index: Optional[int] = None, **kwargs) -> b
         raise QWebInstanceDoesNotExistError("Table has not been defined with UseTable keyword")
     table = Table.ACTIVE_TABLE.update_table()
     columns = table.get_columns()
-    column_texts = _get_column_header_texts(columns)
+    column_texts = table.get_column_header_texts(columns)
     partial = kwargs.get("partial_match", CONFIG["PartialMatch"])
 
     # If index is not specified, verify that the expected text is in any column
     if not index:
         # accept partial match
         if util.par2bool(partial):
-            found = found = any(expected in c for c in column_texts)
+            found = any(expected in c for c in column_texts)
         # full match
         else:
             found = expected in column_texts
@@ -618,12 +618,3 @@ def verify_col_header(expected: str, index: Optional[int] = None, **kwargs) -> b
         return True
 
     raise QWebElementNotFoundError(f'Column "{index}" "{actual}" does not match "{expected}".')
-
-
-def _get_column_header_texts(columns: List[WebElement]) -> List[str]:
-    # prefer using title, then aria-label, then text
-    column_texts = [
-        c.get_attribute("aria-label") or c.get_attribute("title") or c.text for c in columns
-    ]
-
-    return column_texts

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ setuptools>=70.0.0
 # v2.0+ not supported yet
 numpy>=1.23.5,<2
 opencv-python==4.8.1.78
+pypdf==5.4.0
 requests==2.32.2
-slate3k==0.5.3
 scipy>=1.7.3
 scikit-image==0.21;python_version=="3.8"
 scikit-image==0.24;python_version>"3.9"

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
                       "pyscreeze==0.1.28",
                       "pyautogui>=0.9.53",
                       "pynput>=1.7.7",
+                      "pypdf>=5.4.0",
                       'requests>=2.32.2',
                       "robotframework>=5.0.1,<8",
                       "robotframework-debuglibrary==2.5.0",
@@ -58,8 +59,7 @@ setup(
                       "scikit-image==0.24;python_version>'3.8'",
                       "ply",
                       "numpy>=1.23.5,<2",
-                      "opencv-python==4.8.1.78",
-                      "slate3k>=0.5.3"],
+                      "opencv-python==4.8.1.78"],
 
     extras_require={':"linux" in sys_platform': ['xlib'],
                     ':"darwin" in sys_platform': ['pyobjc-core>=9.2', 'pyobjc>=9.2']}


### PR DESCRIPTION
…pports getting full match from known attributes containing column header (if available) in addition to text.

At the same go refactored def get_col_header and verify_col_header -> moved internal support functions to /internal/table. Also slightly renamed them and added own func for getting the column index.

Also changed PDF reading functionality from Slate3k to pypdf. 