### PR TITLE
tests: control headless browser in text2.robot

### DIFF
--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -19,8 +19,9 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["macos-latest-large"]'
-      browser: '["chrome", "edge", "safari"]'
+      os: '["macos-latest"]'
+      #browser: '["chrome", "edge", "safari"]'
+      browser: '["chrome", "safari"]'
       python-version: '["3.10", "3.11"]'
       minimum-rfw-version: "5.0.1"
       minimum-rfw-python: "3.10"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["macos-latest"]'
+      os: '["macos-latest-large"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
       minimum-rfw-version: "5.0.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,4 +14,4 @@ duty
 mypy
 types-setuptools
 types-requests
-robotframework-pabot
+robotframework-pabot<5

--- a/test/acceptance/parallel/text2.robot
+++ b/test/acceptance/parallel/text2.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation                   Tests for text keywords
 Library                         QWeb
-Suite Setup                     OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}                  --HEADLESS
+Suite Setup                     Headless Setup
 Suite Teardown                  CloseBrowser
 Test Timeout                    60 seconds
 
@@ -164,6 +164,7 @@ Child and Parents - Click parent
     [tags]                      PROBLEM_IN_FIREFOX
     VerifyNoText                parent clicked!             timeout=2
     ClickText                   Identifying text            parent=div
+    LogScreenshot
     VerifyText                  parent clicked!
 
 Child and Parents - Click child
@@ -221,3 +222,8 @@ WriteText error in headless mode
     ...                         to be fixed as well.
     ${error}                    Set Variable                QWebEnvironmentError: Running in headless*
     Run Keyword and Expect Error                            ${error}                    WriteText                   Foobar
+
+*** Keywords ***
+Headless Setup                     
+    OpenBrowser                 ${BASE_URI}/text.html                 ${BROWSER}                  --HEADLESS
+    SetConfig                   WindowSize               1920x1080


### PR DESCRIPTION
* added controlled headless window size to text2.robot
* Downgraded pabot as ordering has chenged in 5.0.0
* Removed Edge from MacOs pipeline as Edgedriver is not anymore included in GitHub MacOs images