### PR TITLE
initial

### DIFF
--- a/QWeb/keywords/browser.py
+++ b/QWeb/keywords/browser.py
@@ -357,10 +357,7 @@ def open_browser(url: str, browser_alias: str, options: Optional[str] = None, **
     if os.getenv("QWEB_HEADLESS"):
         kwargs = {"headless": True}
     if os.getenv("CHROME_ARGS") is not None:
-        if option_list is None:
-            option_list = os.getenv("CHROME_ARGS").split(",")
-        else:
-            option_list = option_list + os.getenv("CHROME_ARGS", "").split(",")
+        option_list = option_list + os.getenv("CHROME_ARGS", "").split(", ")
     logger.debug("Options: {}".format(option_list))
 
     bs_project_name = util.get_rfw_variable_value("${PROJECTNAME}") or ""

--- a/test/acceptance/serial/browser_windowed.robot
+++ b/test/acceptance/serial/browser_windowed.robot
@@ -19,13 +19,13 @@ Open Browser With Options
 Open Browser with Environment Chromeargs
     [tags]          PROBLEM_IN_SAFARI
     [Setup]    No Operation
-    Set Environment Variable     CHROME_ARGS    no-sandbox, disable-gpu, disable-impl-side-painting
+    Set Environment Variable     CHROME_ARGS    no-sandbox, disable-gpu, disable-impl-side-painting, --allow-remote-origins=localhost:8000,localhost:8001
     OpenBrowser    about:blank    ${BROWSER}
 
 Open Browser with Options and Environment Chromeargs
     [tags]          PROBLEM_IN_SAFARI
     [Setup]    No Operation
-    Set Environment Variable     CHROME_ARGS    no-sandbox, disable-gpu
+    Set Environment Variable     CHROME_ARGS    no-sandbox, disable-gpu, --allow-remote-origins=localhost:8000,localhost:8001
     OpenBrowser    about:blank    ${BROWSER}    disable-impl-side-painting
 
 Open Browser with experimental args


### PR DESCRIPTION
change CHROME_ARGS split to support comma separated multivalue arguments

TODO: add a validation keyword into the browser argument tests to confirm that the args and the values are correctly in place