### PR TITLE
deps: updated pypdf due to vulnerability warning

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 

--- a/.github/workflows/linux_acceptance.yml
+++ b/.github/workflows/linux_acceptance.yml
@@ -24,5 +24,5 @@ jobs:
       os: '["ubuntu-latest"]'
       browser: '["chrome", "firefox", "edge"]'
       python-version: '["3.11", "3.13"]'
-      minimum-rfw-version: "5.0.1"
+      minimum-rfw-version: "7.0"
       minimum-rfw-python: "3.11"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["macos-14"]'
+      os: '["macos-15"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
       minimum-rfw-version: "5.0.1"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -24,6 +24,6 @@ jobs:
       os: '["macos-latest"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
-      minimum-rfw-version: "5.0.1"
+      minimum-rfw-version: "7.0"
       minimum-rfw-python: "3.10"
       rfw-exclude-tags: "-e RESOLUTION_DEPENDENCY -e FLASK"

--- a/.github/workflows/mac_acceptance.yml
+++ b/.github/workflows/mac_acceptance.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       # arrays for matrices must be given as string for json parsing
       # https://github.community/t/reusable-workflow-with-strategy-matrix/205676
-      os: '["macos-15"]'
+      os: '["macos-latest"]'
       browser: '["chrome", "edge", "safari"]'
       python-version: '["3.10", "3.11"]'
       minimum-rfw-version: "5.0.1"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,9 +23,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
 

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -93,6 +93,12 @@ jobs:
         openbox &
         Openbox_PID=$!
         
+    - name: Setup MacOs display resolution
+      if: runner.os == 'macOS'
+      run: |
+        system_profiler SPDisplaysDataType | grep Resolution
+        "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
+        system_profiler SPDisplaysDataType | grep Resolution
 
     - name: Setup Windows display resolution
       if: runner.os == 'Windows'

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -55,7 +55,7 @@ jobs:
       DISPLAY: :88
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Dotless RFW suite name BASH
       if: runner.os != 'Windows'
@@ -72,7 +72,7 @@ jobs:
         echo RFW_SUITE_NAME=$suite_name >> $env:GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -251,7 +251,7 @@ jobs:
       
     - name: Archive Robot Framework Tests Report
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-report-${{ env.RFW_SUITE_NAME }}
         path: ./result

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -96,6 +96,9 @@ jobs:
     - name: Setup MacOs display resolution
       if: runner.os == 'macOS'
       run: |
+        brew install displayplacer
+        DISPLAY_INFO="$(displayplacer list)"
+        echo "$DISPLAY_INFO"
         system_profiler SPDisplaysDataType | grep Resolution
         "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
         system_profiler SPDisplaysDataType | grep Resolution

--- a/.github/workflows/tests_reusable.yml
+++ b/.github/workflows/tests_reusable.yml
@@ -93,15 +93,75 @@ jobs:
         openbox &
         Openbox_PID=$!
         
-    - name: Setup MacOs display resolution
+    - name: Set macOS display resolution
       if: runner.os == 'macOS'
+      shell: bash
       run: |
-        brew install displayplacer
-        DISPLAY_INFO="$(displayplacer list)"
-        echo "$DISPLAY_INFO"
-        system_profiler SPDisplaysDataType | grep Resolution
-        "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
-        system_profiler SPDisplaysDataType | grep Resolution
+        set -u
+
+        if ! command -v displayplacer >/dev/null 2>&1; then
+          if ! brew install displayplacer; then
+            echo "::warning::Could not install displayplacer; continuing with the default resolution"
+            exit 0
+          fi
+        fi
+
+        DISPLAY_INFO="$(displayplacer list 2>&1)"
+
+        DISPLAY_ID="$(
+          sed -n 's/^Persistent screen id: //p' <<< "$DISPLAY_INFO" |
+          head -n 1
+        )"
+
+        if [[ -z "$DISPLAY_ID" ]]; then
+          echo "::warning::Could not determine the macOS display ID; continuing with the default resolution"
+          exit 0
+        fi
+
+        # Resolutions are tried in order of preference.
+        RESOLUTIONS=(
+          "1920x1080"
+          "1600x1200"
+        )
+
+        SELECTED_RESOLUTION=""
+
+        for RESOLUTION in "${RESOLUTIONS[@]}"; do
+          if grep -q "res:${RESOLUTION}" <<< "$DISPLAY_INFO"; then
+            SELECTED_RESOLUTION="$RESOLUTION"
+            break
+          fi
+        done
+
+        if [[ -z "$SELECTED_RESOLUTION" ]]; then
+          echo "::warning::Neither 1920x1080 nor 1600x1200 is available; continuing with the default resolution"
+          exit 0
+        fi
+
+        echo "Attempting to set macOS display resolution to ${SELECTED_RESOLUTION}"
+
+        if ! displayplacer \
+          "id:${DISPLAY_ID} res:${SELECTED_RESOLUTION} hz:60 color_depth:7 origin:(0,0) degree:0"
+        then
+          echo "::warning::Failed to set resolution to ${SELECTED_RESOLUTION}; continuing with the current resolution"
+          exit 0
+        fi
+
+        sleep 2
+
+        CURRENT_MODE="$(
+          displayplacer list |
+          grep 'current mode' |
+          head -n 1
+        )"
+
+        echo "Current display mode: ${CURRENT_MODE:-unknown}"
+
+        if grep -q "res:${SELECTED_RESOLUTION}" <<< "$CURRENT_MODE"; then
+          echo "macOS display resolution successfully set to ${SELECTED_RESOLUTION}"
+        else
+          echo "::warning::Requested ${SELECTED_RESOLUTION}, but displayplacer reports: ${CURRENT_MODE:-unknown}"
+        fi
 
     - name: Setup Windows display resolution
       if: runner.os == 'Windows'

--- a/.github/workflows/win_acceptance.yml
+++ b/.github/workflows/win_acceptance.yml
@@ -24,7 +24,7 @@ jobs:
       os: '["windows-latest"]'
       browser: '["chrome", "edge", "firefox"]'
       python-version: '["3.11", "3.12"]'
-      minimum-rfw-version: "5.0.1"
+      minimum-rfw-version: "7.0"
       minimum-rfw-python: "3.11"
       rfw-exclude-tags: "-e FLASK"
       

--- a/QWeb/internal/browser/chrome.py
+++ b/QWeb/internal/browser/chrome.py
@@ -131,7 +131,11 @@ def create_chrome_options(chrome_args: Optional[list[str]], **kwargs: Any) -> Op
     if chrome_version:
         options.browser_version = chrome_version
 
-    if user.is_root():
+    apparmor_restricted = user.apparmor_userns_restricted()
+    if apparmor_restricted:
+        logger.info("Linux Chrome detected with AppArmor user namespace restrictions enabled.")
+        logger.info("Adding --no-sandbox to work around Chromium sandbox initialization.")
+    if user.is_root() or apparmor_restricted:
         options.add_argument("no-sandbox")
 
     return options

--- a/QWeb/internal/browser/edge.py
+++ b/QWeb/internal/browser/edge.py
@@ -77,7 +77,12 @@ def create_edge_options(edge_args: Optional[list[str]], **kwargs: Any) -> Option
     options = Options()
     options.add_experimental_option("excludeSwitches", ["enable-logging"])  # pylint: disable=no-member
 
-    if user.is_root() or user.is_docker():
+    apparmor_restricted = user.apparmor_userns_restricted()
+    # Handle AppArmor user namespace restrictions on Linux Chromium-based browsers (like Edge)
+    if apparmor_restricted:
+        logger.info("Linux Edge detected with AppArmor user namespace restrictions enabled.")
+        logger.info("Adding --no-sandbox to work around Chromium sandbox initialization.")
+    if user.is_root() or user.is_docker() or apparmor_restricted:
         options.add_argument("no-sandbox")  # pylint: disable=no-member
     if edge_args:
         if any("--headless" in _.lower() for _ in edge_args):

--- a/QWeb/internal/user.py
+++ b/QWeb/internal/user.py
@@ -19,6 +19,7 @@ import os
 
 
 def is_root() -> bool:
+    """Check if running as root user."""
     try:
         # Windows doesn't have getuid. We just assume that user is not root. We
         # most likely won't need proper Windows support here anyway.
@@ -32,9 +33,22 @@ def is_root() -> bool:
 
 
 def is_docker() -> bool:
+    """Check if running inside a Docker container."""
     path = "/proc/self/cgroup"
     return (
         os.path.exists("/.dockerenv")
         or os.path.isfile(path)
         and any("docker" in line for line in open(path))  # noqa: W503,W1514
     )
+
+
+def apparmor_userns_restricted() -> bool:
+    """Check if AppArmor user namespace restrictions are enabled on Linux."""
+    path = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+    # 0 - not restricted
+    # 1 - restricted
+    try:
+        with open(path) as f:
+            return f.read().strip() == "1"
+    except OSError:
+        return False

--- a/QWeb/keywords/element.py
+++ b/QWeb/keywords/element.py
@@ -26,6 +26,8 @@ from QWeb.internal.exceptions import QWebValueError, QWebElementNotFoundError
 from QWeb.internal import element, decorators, actions, text, input_, dropdown, checkbox
 from QWeb.internal.config_defaults import CONFIG
 
+import time
+
 
 @keyword(tags=["Interaction"])
 @decorators.timeout_decorator
@@ -887,6 +889,7 @@ def get_coordinates(
         # scroll element into view and adjust scroll if needed
         scrolled_position = webelement.location_once_scrolled_into_view
         actions.scroll_overlay_adjustment(overlay_offset)
+        time.sleep(0.25)  # wait for the scroll to complete and the page to stabilize
 
     except Exception as e:
         raise QWebValueError(f"Could not scroll element {locator} into view. Error: {e}") from e

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ See more [examples](#examples).
 
 ---
 ## Requirements
-Python **3.10-3.13** and Robot Framework 5.0.1 or above.
+Python **3.10-3.13** and Robot Framework 7.0 or above.
 
-(Note that support on Macs with Apple based silicon (M1) requires MacOS version 12/Monterey or above or [custom installation](https://github.com/qentinelqi/qweb/blob/master/docs/qweb_mac_m1_installation.md).)
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyscreeze==0.1.28",
     "pyautogui>=0.9.53",
     "pynput>=1.8.0",
-    "pypdf>=6.10.2",
+    "pypdf>=6.14.2",
     "pyperclip==1.9.0",
     "requests>=2.33.0",
     "robotframework>=5.0.1,<8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pypdf>=6.14.2",
     "pyperclip==1.9.0",
     "requests>=2.33.0",
-    "robotframework>=5.0.1,<8",
+    "robotframework>=7.0,<8",
     "robotframework-debuglibrary==2.5.0",
     "selenium>=4.27.0,<5",
     "Pillow>=12.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ setuptools>=78.1.1
 # v2.0+ not supported yet
 numpy>=2.0.0
 opencv-python==4.11.0.86
-pypdf==6.10.2
+pypdf==6.14.2
 requests==2.33.0
 scipy>= 1.10.0
 scikit-image==0.25.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyScreeze==0.1.28
 pyperclip==1.9.0
 PyAutoGUI>=0.9.53
 Pillow>=12.2.0
-robotframework>=5.0.1,<8
+robotframework>=7.0,<8
 robotframework-debuglibrary==2.5.0
 selenium>=4.27.0,<5
 pynput==1.8.1

--- a/test/acceptance/serial/browser_windowed.robot
+++ b/test/acceptance/serial/browser_windowed.robot
@@ -122,7 +122,7 @@ Open Browser with driver logging
 
 Open Browser with non-valid page load strategy
     [Setup]    No Operation
-    [tags]         page_load_strategy
+    [tags]         page_load_strategy    PROBLEM_IN_SAFARI
     Run Keyword And Expect Error    ValueError: Strategy can only be one of the following: normal, eager, none*    OpenBrowser     about:blank     ${BROWSER}         page_load_strategy=non-valid
     CloseAllBrowsers
 

--- a/test/acceptance/serial/browser_windowed.robot
+++ b/test/acceptance/serial/browser_windowed.robot
@@ -127,7 +127,7 @@ Open Browser with non-valid page load strategy
     CloseAllBrowsers
 
 Open Browser with default page load strategy
-    [tags]         page_load_strategy
+    [tags]         page_load_strategy    PROBLEM_IN_SAFARI
     [Setup]    No Operation
     OpenBrowser     about:blank     ${BROWSER}
     ${driver}=      Return Browser
@@ -136,7 +136,7 @@ Open Browser with default page load strategy
     CloseAllBrowsers
 
 Open Browser with valid page load strategies
-    [tags]          page_load_strategy
+    [tags]          page_load_strategy    PROBLEM_IN_SAFARI
     [Setup]    No Operation
     OpenBrowser     about:blank     ${BROWSER}       page_load_strategy=normal
     ${driver}=      Return Browser

--- a/test/acceptance/serial/mouse.robot
+++ b/test/acceptance/serial/mouse.robot
@@ -19,8 +19,10 @@ Click And Hold with text
     VerifyText          Mouse Click and Hold Test
     MouseDown           Click and Hold Me!  element_type=text
     Sleep               2
+    LogScreenshot
     MouseUp             Click and Hold Me!  element_type=text
     Sleep               1
+    LogScreenshot
     ${ms}=              GetText     millisecondsField   tag=span
     Should Be True      ${ms} > 2000
 

--- a/test/acceptance/serial/mouse.robot
+++ b/test/acceptance/serial/mouse.robot
@@ -20,6 +20,7 @@ Click And Hold with text
     MouseDown           Click and Hold Me!  element_type=text
     Sleep               2
     MouseUp             Click and Hold Me!  element_type=text
+    Sleep               1
     ${ms}=              GetText     millisecondsField   tag=span
     Should Be True      ${ms} > 2000
 
@@ -29,6 +30,7 @@ Click And Hold with xpath
     MouseDown           //button[@id\="clickAndHoldButton"]
     Sleep               1
     MouseUp             //button[@id\="clickAndHoldButton"]
+    Sleep               1
     ${ms}=              GetText     millisecondsField   tag=span
     Should Be True      ${ms} > 1000 
 
@@ -38,6 +40,7 @@ Click And Hold with attribute
     MouseDown           clickAndHoldButton  element_type=item
     Sleep               3
     MouseUp             clickAndHoldButton  element_type=item
+    Sleep               1
     ${ms}=              GetText     millisecondsField   tag=span
     Should Be True      ${ms} > 3000
 


### PR DESCRIPTION
Regardless of the subject, this PR includes the following:
- Pipeline fixes
  - Ubuntu 24.04 made default, needs **apparmor** fix below
  - `macos-14` was deprecated, moved to `macos-latest`
- Added new check for Apparmor restriction; if Chrome/Edge are restricted, we add `--no-sandbox` automatically. 
   - This seems to happen for system installed Edge in GitHub and Selenium Manager installed Edge/Chrome in Ubuntu
 - Made Robot FW `7.0` the minimum supported version
- Updated `pypdf` dependency due to vulnerability warning
- Updated GitHub action(s) to newer versions
- Added similar **resolution** configuration for GitHub Mac as we already had for Win & linux
- Added a **small delay** between scrolling into view and getting coordinates (in def **get_coordinates**)
  - This was only an issue with latest GitHub Mac image with Safari and Python 3.10. Previous mac image worked, local runs worked and all other images/browsers worked. Fun.  