### PR TITLE
deps: bumped lowest allowed version of pypdf due to vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pyscreeze==0.1.28",
     "pyautogui>=0.9.53",
     "pynput>=1.8.0",
-    "pypdf>=6.14.2",
+    "pypdf>=6.15.0",
     "pyperclip==1.9.0",
     "requests>=2.33.0",
     "robotframework>=7.0,<8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ setuptools>=78.1.1
 # v2.0+ not supported yet
 numpy>=2.0.0
 opencv-python==4.11.0.86
-pypdf==6.14.2
+pypdf>=6.15.0
 requests==2.33.0
 scipy>= 1.10.0
 scikit-image==0.25.2


### PR DESCRIPTION
pypdf lowest allowed version bumped to 6.15.0 due to:

* https://github.com/qentinelqi/qweb/security/dependabot/58
* https://github.com/qentinelqi/qweb/security/dependabot/57